### PR TITLE
Close classes off from inheritance

### DIFF
--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -19,7 +19,10 @@ use CultuurNet\CalendarSummaryV3\Periodic\SmallPeriodicHTMLFormatter;
 
 final class CalendarHTMLFormatter implements CalendarFormatterInterface
 {
-    protected $mapping = array();
+    /**
+     * @var array[]
+     */
+    private $mapping;
 
     public function __construct($langCode = 'nl_BE', $hidePastDates = false, $timeZone = 'Europe/Brussels')
     {

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -17,7 +17,7 @@ use CultuurNet\CalendarSummaryV3\Periodic\LargePeriodicHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\Periodic\SmallPeriodicHTMLFormatter;
 
-class CalendarHTMLFormatter implements CalendarFormatterInterface
+final class CalendarHTMLFormatter implements CalendarFormatterInterface
 {
     protected $mapping = array();
 

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -17,7 +17,7 @@ use CultuurNet\CalendarSummaryV3\Permanent\LargePermanentPlainTextFormatter;
 use CultuurNet\CalendarSummaryV3\Multiple\LargeMultiplePlainTextFormatter;
 use CultuurNet\CalendarSummaryV3\Multiple\MediumMultiplePlainTextFormatter;
 
-class CalendarPlainTextFormatter implements CalendarFormatterInterface
+final class CalendarPlainTextFormatter implements CalendarFormatterInterface
 {
     protected $mapping = array();
 

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -19,7 +19,10 @@ use CultuurNet\CalendarSummaryV3\Multiple\MediumMultiplePlainTextFormatter;
 
 final class CalendarPlainTextFormatter implements CalendarFormatterInterface
 {
-    protected $mapping = array();
+    /**
+     * @var array[]
+     */
+    private $mapping;
 
     public function __construct($langCode = 'nl_BE', $hidePastDates = false, $timeZone = 'Europe/Brussels')
     {

--- a/src/FormatterException.php
+++ b/src/FormatterException.php
@@ -4,7 +4,7 @@ namespace CultuurNet\CalendarSummaryV3;
 
 use Exception;
 
-class FormatterException extends \Exception
+final class FormatterException extends \Exception
 {
 
 }

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -11,7 +11,7 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -6,7 +6,7 @@ use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use DateTimeZone;
 
-class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterface
+final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
      * @var Translator

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -6,7 +6,7 @@ use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use DateTimeZone;
 
-class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInterface
+final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
      * @var Translator

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -11,7 +11,7 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Multiple/LargeMultipleHTMLFormatter.php
+++ b/src/Multiple/LargeMultipleHTMLFormatter.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\LargeSingleHTMLFormatter;
 
-class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
+final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
      * @var string $langCode

--- a/src/Multiple/LargeMultipleHTMLFormatter.php
+++ b/src/Multiple/LargeMultipleHTMLFormatter.php
@@ -10,7 +10,7 @@ final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
     /**
      * @var string $langCode
      */
-    protected $langCode;
+    private $langCode;
 
     /**
      * @var bool $hidePast

--- a/src/Multiple/LargeMultipleHTMLFormatter.php
+++ b/src/Multiple/LargeMultipleHTMLFormatter.php
@@ -15,7 +15,7 @@ final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
     /**
      * @var bool $hidePast
      */
-    protected $hidePast;
+    private $hidePast;
 
     public function __construct(string $langCode, bool $hidePastDates)
     {

--- a/src/Multiple/LargeMultiplePlainTextFormatter.php
+++ b/src/Multiple/LargeMultiplePlainTextFormatter.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\LargeSinglePlainTextFormatter;
 
-class LargeMultiplePlainTextFormatter implements MultipleFormatterInterface
+final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
      * @var string $langCode

--- a/src/Multiple/LargeMultiplePlainTextFormatter.php
+++ b/src/Multiple/LargeMultiplePlainTextFormatter.php
@@ -15,7 +15,7 @@ final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterfac
     /**
      * @var bool $hidePast
      */
-    protected $hidePast;
+    private $hidePast;
 
     public function __construct(string $langCode, bool $hidePastDates)
     {

--- a/src/Multiple/LargeMultiplePlainTextFormatter.php
+++ b/src/Multiple/LargeMultiplePlainTextFormatter.php
@@ -10,7 +10,7 @@ final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterfac
     /**
      * @var string $langCode
      */
-    protected $langCode;
+    private $langCode;
 
     /**
      * @var bool $hidePast

--- a/src/Multiple/MediumMultipleHTMLFormatter.php
+++ b/src/Multiple/MediumMultipleHTMLFormatter.php
@@ -15,7 +15,7 @@ final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
     /**
      * @var bool $hidepast
      */
-    protected $hidePast;
+    private $hidePast;
 
     public function __construct(string $langCode, bool $hidePastDates)
     {

--- a/src/Multiple/MediumMultipleHTMLFormatter.php
+++ b/src/Multiple/MediumMultipleHTMLFormatter.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\MediumSingleHTMLFormatter;
 
-class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
+final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
      * @var string $langCode

--- a/src/Multiple/MediumMultipleHTMLFormatter.php
+++ b/src/Multiple/MediumMultipleHTMLFormatter.php
@@ -10,7 +10,7 @@ final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
     /**
      * @var string $langCode
      */
-    protected $langCode;
+    private $langCode;
 
     /**
      * @var bool $hidepast

--- a/src/Multiple/MediumMultiplePlainTextFormatter.php
+++ b/src/Multiple/MediumMultiplePlainTextFormatter.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\MediumSinglePlainTextFormatter;
 
-class MediumMultiplePlainTextFormatter implements MultipleFormatterInterface
+final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
      * @var string $langCode

--- a/src/Multiple/MediumMultiplePlainTextFormatter.php
+++ b/src/Multiple/MediumMultiplePlainTextFormatter.php
@@ -15,7 +15,7 @@ final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterfa
     /**
      * @var bool $hidepast
      */
-    protected $hidePast;
+    private $hidePast;
 
     public function __construct(string $langCode, bool $hidePastDates)
     {

--- a/src/Multiple/MediumMultiplePlainTextFormatter.php
+++ b/src/Multiple/MediumMultiplePlainTextFormatter.php
@@ -10,7 +10,7 @@ final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterfa
     /**
      * @var string $langCode
      */
-    protected $langCode;
+    private $langCode;
 
     /**
      * @var bool $hidepast

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -10,7 +10,7 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
     /**
      * @var string
      */
-    protected $langCode;
+    private $langCode;
 
     public function __construct(string $langCode)
     {

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicHTMLFormatter;
 use CultuurNet\SearchV3\ValueObjects\Event;
 
-class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
+final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
      * @var string

--- a/src/Multiple/SmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/SmallMultiplePlainTextFormatter.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicPlainTextFormatter;
 use CultuurNet\SearchV3\ValueObjects\Event;
 
-class SmallMultiplePlainTextFormatter implements MultipleFormatterInterface
+final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
      * @var string

--- a/src/Multiple/SmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/SmallMultiplePlainTextFormatter.php
@@ -10,7 +10,7 @@ final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterfac
     /**
      * @var string
      */
-    protected $langCode;
+    private $langCode;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -8,7 +8,7 @@ use \DateTime;
 use \DateTimeInterface;
 use IntlDateFormatter;
 
-class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
+final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -13,12 +13,12 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtMonth;
+    private $fmtMonth;
 
     /**
      * @var Translator

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -23,7 +23,7 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -8,7 +8,7 @@ use \DateTime;
 use \DateTimeInterface;
 use IntlDateFormatter;
 
-class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInterface
+final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -23,7 +23,7 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -13,12 +13,12 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtMonth;
+    private $fmtMonth;
 
     /**
      * @var Translator

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -27,7 +27,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTime;
 use IntlDateFormatter;
 
-class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
+final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -148,7 +148,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      * @param DateTime $dateTo
      * @return string
      */
-    protected function generateDates(DateTime $dateFrom, DateTime $dateTo)
+    private function generateDates(DateTime $dateFrom, DateTime $dateTo)
     {
 
         $intlDateFrom =$this->fmt->format($dateFrom);
@@ -168,7 +168,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      * @param $openingHoursData
      * @return string
      */
-    protected function generateWeekScheme($openingHoursData)
+    private function generateWeekScheme($openingHoursData)
     {
         $outputWeek = '<p class="cf-openinghours">' . $this->trans->getTranslations()->t('open') . ':</p>';
         $outputWeek .= '<ul class="list-unstyled">';

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -80,7 +80,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      * @param $calsum
      * @return mixed
      */
-    protected function formatSummary($calsum)
+    private function formatSummary($calsum)
     {
         $calsum = str_replace('><', '> <', $calsum);
         return str_replace('  ', ' ', $calsum);

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -90,7 +90,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      * @param $time
      * @return string
      */
-    protected function getFormattedTime($time)
+    private function getFormattedTime($time)
     {
         $formattedShortTime = ltrim($time, '0');
         if ($formattedShortTime == ':00') {
@@ -106,7 +106,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      * @param $daysOfWeek
      * @return string
      */
-    protected function getEarliestTime($openingHoursData, $daysOfWeek)
+    private function getEarliestTime($openingHoursData, $daysOfWeek)
     {
         $earliest = '';
         foreach ($openingHoursData as $openingHours) {
@@ -128,7 +128,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      * @param $daysOfWeek
      * @return string
      */
-    protected function getLatestTime($openingHoursData, $daysOfWeek)
+    private function getLatestTime($openingHoursData, $daysOfWeek)
     {
         $latest = '';
         foreach ($openingHoursData as $openingHours) {

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -12,17 +12,17 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDays;
+    private $fmtDays;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtShortDays;
+    private $fmtShortDays;
 
     /**
      * @var Translator

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -86,7 +86,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         return $formattedShortTime;
     }
 
-    protected function generateDates(DateTime $dateFrom, DateTime $dateTo): string
+    private function generateDates(DateTime $dateFrom, DateTime $dateTo): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlDateTo = $this->fmt->format($dateTo);
@@ -100,7 +100,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
      * @param OpeningHours[]
      * @return string
      */
-    protected function generateWeekScheme(array $openingHoursData): string
+    private function generateWeekScheme(array $openingHoursData): string
     {
         $outputWeek = '(';
 

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -8,7 +8,7 @@ use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use DateTime;
 use IntlDateFormatter;
 
-class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterface
+final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -77,7 +77,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         return $output;
     }
 
-    protected function getFormattedTime(string $time): string
+    private function getFormattedTime(string $time): string
     {
         $formattedShortTime = ltrim($time, '0');
         if ($formattedShortTime == ':00') {

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -13,17 +13,17 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDays;
+    private $fmtDays;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtShortDays;
+    private $fmtShortDays;
 
     /**
      * @var Translator

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -28,7 +28,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -11,12 +11,12 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var Translator

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -6,7 +6,7 @@ use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use IntlDateFormatter;
 
-class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
+final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -21,7 +21,7 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -11,12 +11,12 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var Translator

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -6,7 +6,7 @@ use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use IntlDateFormatter;
 
-class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterface
+final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -21,7 +21,7 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -13,12 +13,12 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtMonth;
+    private $fmtMonth;
 
     /**
      * @var Translator

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -23,7 +23,7 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -8,7 +8,7 @@ use \DateTime;
 use \DateTimeInterface;
 use IntlDateFormatter;
 
-class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
+final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -13,12 +13,12 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtMonth;
+    private $fmtMonth;
 
     /**
      * @var Translator

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -23,7 +23,7 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -8,7 +8,7 @@ use \DateTime;
 use \DateTimeInterface;
 use IntlDateFormatter;
 
-class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterface
+final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use IntlDateFormatter;
 
-class LargePermanentHTMLFormatter implements PermanentFormatterInterface
+final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 {
     protected $daysOfWeek = array(
         'monday',

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -22,12 +22,12 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDays;
+    private $fmtDays;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtShortDays;
+    private $fmtShortDays;
 
     /**
      * @var Translator

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -80,7 +80,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
         return $formattedShortTime;
     }
 
-    protected function formatSummary(string $calsum): string
+    private function formatSummary(string $calsum): string
     {
         $calsum = str_replace('><', '> <', $calsum);
         return str_replace('  ', ' ', $calsum);

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -71,7 +71,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
         return $this->formatSummary($output);
     }
 
-    protected function getFormattedTime(string $time): string
+    private function getFormattedTime(string $time): string
     {
         $formattedShortTime = ltrim($time, '0');
         if ($formattedShortTime == ':00') {
@@ -93,7 +93,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
      * @param string[] $daysOfWeek
      * @return string
      */
-    protected function getEarliestTime(array $openingHoursData, array $daysOfWeek): string
+    private function getEarliestTime(array $openingHoursData, array $daysOfWeek): string
     {
         $earliest = '';
         foreach ($openingHoursData as $openingHours) {
@@ -115,7 +115,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
      * @param string[] $daysOfWeek
      * @return string
      */
-    protected function getLatestTime(array $openingHoursData, array $daysOfWeek): string
+    private function getLatestTime(array $openingHoursData, array $daysOfWeek): string
     {
         $latest = '';
         foreach ($openingHoursData as $openingHours) {

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -9,7 +9,7 @@ use IntlDateFormatter;
 
 final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 {
-    protected $daysOfWeek = array(
+    private $daysOfWeek = array(
         'monday',
         'tuesday',
         'wednesday',

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -130,7 +130,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
         return $latest;
     }
 
-    protected function generateFormattedTimespan(string $dayOfWeek, bool $long = false): string
+    private function generateFormattedTimespan(string $dayOfWeek, bool $long = false): string
     {
         if ($long) {
             return ucfirst($this->trans->getTranslations()->t($dayOfWeek));
@@ -143,7 +143,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @param OpeningHours[] $openingHoursData
      */
-    protected function generateWeekScheme(array $openingHoursData): string
+    private function generateWeekScheme(array $openingHoursData): string
     {
         $outputWeek = '<ul class="list-unstyled">';
         // Create an array with formatted timespans.

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -32,7 +32,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -9,7 +9,7 @@ use IntlDateFormatter;
 
 final class LargePermanentPlainTextFormatter implements PermanentFormatterInterface
 {
-    protected $daysOfWeek = array(
+    private $daysOfWeek = array(
         'monday',
         'tuesday',
         'wednesday',

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -69,7 +69,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
         return $output;
     }
 
-    protected function getFormattedTime(string $time): string
+    private function getFormattedTime(string $time): string
     {
         $formattedShortTime = ltrim($time, '0');
         if ($formattedShortTime == ':00') {

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use IntlDateFormatter;
 
-class LargePermanentPlainTextFormatter implements PermanentFormatterInterface
+final class LargePermanentPlainTextFormatter implements PermanentFormatterInterface
 {
     protected $daysOfWeek = array(
         'monday',

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -32,7 +32,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -82,7 +82,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
      * @param OpeningHours[] $openingHoursData
      * @return string
      */
-    protected function generateWeekScheme(array $openingHoursData): string
+    private function generateWeekScheme(array $openingHoursData): string
     {
         $outputWeek = '';
         // Create an array with formatted days.

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -22,12 +22,12 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDays;
+    private $fmtDays;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtShortDays;
+    private $fmtShortDays;
 
     /**
      * @var Translator

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -67,7 +67,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
      * @param OpeningHours[] $openingHoursData
      * @return string
      */
-    protected function generateWeekScheme(array $openingHoursData): string
+    private function generateWeekScheme(array $openingHoursData): string
     {
         $outputWeek = '<span>' . ucfirst($this->trans->getTranslations()->t('open')) . ' '
             . '<span class="cf-weekdays">';

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -12,12 +12,12 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDays;
+    private $fmtDays;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtShortDays;
+    private $fmtShortDays;
 
     /**
      * @var Translator

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use IntlDateFormatter;
 
-class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
+final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -22,7 +22,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -12,12 +12,12 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDays;
+    private $fmtDays;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtShortDays;
+    private $fmtShortDays;
 
     /**
      * @var Translator

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use IntlDateFormatter;
 
-class MediumPermanentPlainTextFormatter implements PermanentFormatterInterface
+final class MediumPermanentPlainTextFormatter implements PermanentFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -22,7 +22,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -64,7 +64,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
      * @param OpeningHours[] $openingHoursData
      * @return string
      */
-    protected function generateWeekScheme(array $openingHoursData): string
+    private function generateWeekScheme(array $openingHoursData): string
     {
         $outputWeek = ucfirst($this->trans->getTranslations()->t('open')) . ' ';
         // Create an array with formatted days.

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -12,17 +12,17 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtWeekDayLong;
+    private $fmtWeekDayLong;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtTime;
+    private $fmtTime;
 
     /**
      * @var Translator

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -76,7 +76,7 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatSameDay(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatSameDay(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlWeekDayFrom = $this->fmtWeekDayLong->format($dateFrom);
@@ -121,7 +121,7 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlWeekDayFrom = $this->fmtWeekDayLong->format($dateFrom);

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -27,7 +27,7 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTimeInterface;
 use IntlDateFormatter;
 
-class LargeSingleHTMLFormatter implements SingleFormatterInterface
+final class LargeSingleHTMLFormatter implements SingleFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTimeInterface;
 use IntlDateFormatter;
 
-class LargeSinglePlainTextFormatter implements SingleFormatterInterface
+final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -27,7 +27,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -76,7 +76,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatSameDay(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatSameDay(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlWeekDayFrom = $this->fmtWeekDayLong->format($dateFrom);
@@ -99,7 +99,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlWeekDayFrom = $this->fmtWeekDayLong->format($dateFrom);

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -12,17 +12,17 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtWeekDayLong;
+    private $fmtWeekDayLong;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtTime;
+    private $fmtTime;
 
     /**
      * @var Translator

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTimeInterface;
 use IntlDateFormatter;
 
-class MediumSingleHTMLFormatter implements SingleFormatterInterface
+final class MediumSingleHTMLFormatter implements SingleFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -12,12 +12,12 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var Translator

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -62,7 +62,7 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatSameDay(DateTimeInterface $dateFrom): string
+    private function formatSameDay(DateTimeInterface $dateFrom): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlDateDayFrom = $this->fmtDay->format($dateFrom);
@@ -74,7 +74,7 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlDateDayFrom = $this->fmtDay->format($dateFrom);

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -22,7 +22,7 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -62,7 +62,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatSameDay(DateTimeInterface $dateFrom): string
+    private function formatSameDay(DateTimeInterface $dateFrom): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlDateDayFrom = $this->fmtDay->format($dateFrom);
@@ -72,7 +72,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->fmt->format($dateFrom);
         $intlDateDayFrom = $this->fmtDay->format($dateFrom);

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -22,7 +22,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTimeInterface;
 use IntlDateFormatter;
 
-class MediumSinglePlainTextFormatter implements SingleFormatterInterface
+final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -12,12 +12,12 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmt;
+    private $fmt;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var Translator

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -22,7 +22,7 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -62,7 +62,7 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatSameDay(DateTimeInterface $dateFrom): string
+    private function formatSameDay(DateTimeInterface $dateFrom): string
     {
         $dateFromDay = $this->fmtDay->format($dateFrom);
         $dateFromMonth = rtrim($this->fmtMonth->format($dateFrom), '.');
@@ -74,7 +74,7 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $dateFromDay = $this->fmtDay->format($dateFrom);
         $dateFromMonth = rtrim($this->fmtMonth->format($dateFrom), '.');

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -12,12 +12,12 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtMonth;
+    private $fmtMonth;
 
     /**
      * @var Translator

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTimeInterface;
 use IntlDateFormatter;
 
-class SmallSingleHTMLFormatter implements SingleFormatterInterface
+final class SmallSingleHTMLFormatter implements SingleFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -12,12 +12,12 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtDay;
+    private $fmtDay;
 
     /**
      * @var IntlDateFormatter
      */
-    protected $fmtMonth;
+    private $fmtMonth;
 
     /**
      * @var Translator

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -62,7 +62,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatSameDay(DateTimeInterface $dateFrom): string
+    private function formatSameDay(DateTimeInterface $dateFrom): string
     {
         $dateFromDay = $this->fmtDay->format($dateFrom);
         $dateFromMonth = rtrim($this->fmtMonth->format($dateFrom), '.');
@@ -72,7 +72,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
         return $output;
     }
 
-    protected function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
+    private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $dateFromDay = $this->fmtDay->format($dateFrom);
         $dateFromMonth = rtrim($this->fmtMonth->format($dateFrom), '.');

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -7,7 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Offer;
 use DateTimeInterface;
 use IntlDateFormatter;
 
-class SmallSinglePlainTextFormatter implements SingleFormatterInterface
+final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
 {
     /**
      * @var IntlDateFormatter

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -22,7 +22,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    protected $trans;
+    private $trans;
 
     public function __construct(string $langCode)
     {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -10,7 +10,7 @@ final class Translator
     /**
      * @var Translate
      */
-    protected $translator;
+    private $translator;
 
     public function __construct()
     {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -5,7 +5,7 @@ namespace CultuurNet\CalendarSummaryV3;
 use DElfimov\Translate\Translate;
 use DElfimov\Translate\Loader\PhpArrayLoader;
 
-class Translator
+final class Translator
 {
     /**
      * @var Translate


### PR DESCRIPTION
### Added

- Added `final` keyword to all classes

### Changed

- Changed the `protected` properties and functions to `private`

---

Warning! This points to #21 since I could only do the change from protected to private once the abstract classes were gone.