### PR TITLE
Remove creation of new event objects

### DIFF
--- a/src/Multiple/LargeMultipleHTMLFormatter.php
+++ b/src/Multiple/LargeMultipleHTMLFormatter.php
@@ -32,12 +32,8 @@ final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
         foreach ($subEvents as $subEvent) {
             $formatter = new LargeSingleHTMLFormatter($this->langCode);
 
-            $event = new Event();
-            $event->setStartDate($subEvent->getStartDate());
-            $event->setEndDate($subEvent->getEndDate());
-
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
-                $output .= '<li>' . $formatter->format($event) . '</li>';
+                $output .= '<li>' . $formatter->format($subEvent) . '</li>';
             }
         }
 

--- a/src/Multiple/LargeMultiplePlainTextFormatter.php
+++ b/src/Multiple/LargeMultiplePlainTextFormatter.php
@@ -32,12 +32,8 @@ final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterfac
         foreach ($subEvents as $key => $subEvent) {
             $formatter = new LargeSinglePlainTextFormatter($this->langCode);
 
-            $event = new Event();
-            $event->setStartDate($subEvent->getStartDate());
-            $event->setEndDate($subEvent->getEndDate());
-
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
-                $output[] = $formatter->format($event);
+                $output[] = $formatter->format($subEvent);
             }
         }
 

--- a/src/Multiple/MediumMultipleHTMLFormatter.php
+++ b/src/Multiple/MediumMultipleHTMLFormatter.php
@@ -32,12 +32,8 @@ final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
         foreach ($subEvents as $subEvent) {
             $formatter = new MediumSingleHTMLFormatter($this->langCode);
 
-            $event = new Event();
-            $event->setStartDate($subEvent->getStartDate());
-            $event->setEndDate($subEvent->getEndDate());
-
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
-                $output .= '<li>' . $formatter->format($event) . '</li>';
+                $output .= '<li>' . $formatter->format($subEvent) . '</li>';
             }
         }
 

--- a/src/Multiple/MediumMultiplePlainTextFormatter.php
+++ b/src/Multiple/MediumMultiplePlainTextFormatter.php
@@ -32,12 +32,8 @@ final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterfa
         foreach ($subEvents as $key => $subEvent) {
             $formatter = new MediumSinglePlainTextFormatter($this->langCode);
 
-            $event = new Event();
-            $event->setStartDate($subEvent->getStartDate());
-            $event->setEndDate($subEvent->getEndDate());
-
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
-                $output[] = $formatter->format($event);
+                $output[] = $formatter->format($subEvent);
             }
         }
 


### PR DESCRIPTION
### Removed

- Removed creation of new `Event` object when formatting subEvents that are an `Event` anyway

---

Note: This would also cause problems when we implement the status changes, because the status would not be copied over this way.

Follow up to #29 because it would cause merge conflicts otherwise.