### PR TITLE
Only check if start and end are on the same day, not the time

### DIFF
--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
@@ -31,7 +32,7 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
         $dateFrom = $event->getStartDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
         $dateTo = $event->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
-        if ($dateFrom == $dateTo) {
+        if (DateComparison::onSameDay($dateFrom, $dateTo)) {
             return '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span>';
         }
 

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
@@ -31,7 +32,7 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
         $dateFrom = $event->getStartDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
         $dateTo = $event->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
-        if ($dateFrom == $dateTo) {
+        if (DateComparison::onSameDay($dateFrom, $dateTo)) {
             return $this->formatter->formatAsShortDate($dateFrom);
         }
 

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -56,11 +56,11 @@ class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
     }
 
-    public function testFormatAMultipleWithSameBeginAndEndDate(): void
+    public function testFormatAMultipleWithSameBeginAndEndDay(): void
     {
         $offer = new Event();
-        $offer->setStartDate(new \DateTime('08-10-2025'));
-        $offer->setEndDate(new \DateTime('08-10-2025'));
+        $offer->setStartDate(new \DateTime('08-10-2025 12:00'));
+        $offer->setEndDate(new \DateTime('08-10-2025 14:00'));
 
         $output = '<span class="cf-date">8/10/25</span>';
 


### PR DESCRIPTION
### Changed

- Changed the date comparison in the extra small multiple formatters. These formatters only prints the date, e.g. '25/10/21', or a date range, e.g. '25/10/21 till 26/10/21'. However with the previous implementation, if the start and end date were on the same day but the time was different, it would print '25/10/21 till 25/10/21'