### PR TITLE
Fix time formatting between 0am and 1am

### DIFF
--- a/src/OpeningHourFormatter.php
+++ b/src/OpeningHourFormatter.php
@@ -15,14 +15,10 @@ final class OpeningHourFormatter
      */
     public static function format(string $openingHour): string
     {
-        $timeParts = explode(':', $openingHour);
-
-        $hour = ltrim($timeParts[0], '0');
-        if ($hour === '') {
-            $hour = '0';
+        $firstCharacter = $openingHour[0];
+        if ($firstCharacter === '0') {
+            $openingHour = substr($openingHour, 1);
         }
-
-        $timeParts[0] = $hour;
-        return implode(':', $timeParts);
+        return $openingHour;
     }
 }

--- a/src/OpeningHourFormatter.php
+++ b/src/OpeningHourFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3;
+
+final class OpeningHourFormatter
+{
+    /**
+     * Removes the leading 0 from the hour.
+     * For example 00:15 -> 0:15, 01:00 -> 1:00, etc.
+     *
+     * @param string $openingHour
+     * @return string
+     */
+    public static function format(string $openingHour): string
+    {
+        $timeParts = explode(':', $openingHour);
+
+        $hour = ltrim($timeParts[0], '0');
+        if ($hour === '') {
+            $hour = '0';
+        }
+
+        $timeParts[0] = $hour;
+        return implode(':', $timeParts);
+    }
+}

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -51,11 +51,13 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
 
     private function getFormattedTime(string $time): string
     {
-        $formattedShortTime = ltrim($time, '0');
-        if ($formattedShortTime == ':00') {
-            $formattedShortTime = '0:00';
+        $timeParts = explode(':', $time);
+        $hour = ltrim($timeParts[0], '0');
+        if ($hour === '') {
+            $hour = '0';
         }
-        return $formattedShortTime;
+        $timeParts[0] = $hour;
+        return implode(':', $timeParts);
     }
 
     /**

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
+use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
@@ -47,17 +48,6 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
     {
         $calsum = str_replace('><', '> <', $calsum);
         return str_replace('  ', ' ', $calsum);
-    }
-
-    private function getFormattedTime(string $time): string
-    {
-        $timeParts = explode(':', $time);
-        $hour = ltrim($timeParts[0], '0');
-        if ($hour === '') {
-            $hour = '0';
-        }
-        $timeParts[0] = $hour;
-        return implode(':', $timeParts);
     }
 
     /**
@@ -137,10 +127,10 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
 
         foreach ($openingHoursData as $openingHours) {
             $daysOfWeek = $openingHours->getDaysOfWeek();
-            $firstOpens = $this->getFormattedTime($this->getEarliestTime($openingHoursData, $daysOfWeek));
-            $lastCloses = $this->getFormattedTime($this->getLatestTime($openingHoursData, $daysOfWeek));
-            $opens = $this->getFormattedTime($openingHours->getOpens());
-            $closes = $this->getFormattedTime($openingHours->getCloses());
+            $firstOpens = OpeningHourFormatter::format($this->getEarliestTime($openingHoursData, $daysOfWeek));
+            $lastCloses = OpeningHourFormatter::format($this->getLatestTime($openingHoursData, $daysOfWeek));
+            $opens = OpeningHourFormatter::format($openingHours->getOpens());
+            $closes = OpeningHourFormatter::format($openingHours->getCloses());
 
             foreach ($daysOfWeek as $dayOfWeek) {
                 $daySpanShort = ucfirst(

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -45,11 +45,13 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
 
     private function getFormattedTime(string $time): string
     {
-        $formattedShortTime = ltrim($time, '0');
-        if ($formattedShortTime == ':00') {
-            $formattedShortTime = '0:00';
+        $timeParts = explode(':', $time);
+        $hour = ltrim($timeParts[0], '0');
+        if ($hour === '') {
+            $hour = '0';
         }
-        return $formattedShortTime;
+        $timeParts[0] = $hour;
+        return implode(':', $timeParts);
     }
 
     private function generateDates(DateTime $dateFrom, DateTime $dateTo): string

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
+use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
@@ -43,17 +44,6 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         return $output;
     }
 
-    private function getFormattedTime(string $time): string
-    {
-        $timeParts = explode(':', $time);
-        $hour = ltrim($timeParts[0], '0');
-        if ($hour === '') {
-            $hour = '0';
-        }
-        $timeParts[0] = $hour;
-        return implode(':', $timeParts);
-    }
-
     private function generateDates(DateTime $dateFrom, DateTime $dateTo): string
     {
         $intlDateFrom = $this->formatter->formatAsFullDate($dateFrom);
@@ -80,15 +70,15 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
                 if (!isset($formattedDays[$dayOfWeek])) {
                     $formattedDays[$dayOfWeek] = $translatedDay
                         . ' ' . $this->trans->getTranslations()->t('from') . ' '
-                        . $this->getFormattedTime($openingHours->getOpens())
+                        . OpeningHourFormatter::format($openingHours->getOpens())
                         . ' ' . $this->trans->getTranslations()->t('till') . ' '
-                        . $this->getFormattedTime($openingHours->getCloses());
+                        . OpeningHourFormatter::format($openingHours->getCloses());
                 } else {
                     $formattedDays[$dayOfWeek] .= ' ' . $this->trans->getTranslations()->t('and') . ' '
                         . $this->trans->getTranslations()->t('from') . ' '
-                        . $this->getFormattedTime($openingHours->getOpens())
+                        . OpeningHourFormatter::format($openingHours->getOpens())
                         . ' ' . $this->trans->getTranslations()->t('till') . ' '
-                        . $this->getFormattedTime($openingHours->getCloses());
+                        . OpeningHourFormatter::format($openingHours->getCloses());
                 }
             }
         }

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -53,11 +53,13 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
     private function getFormattedTime(string $time): string
     {
-        $formattedShortTime = ltrim($time, '0');
-        if ($formattedShortTime == ':00') {
-            $formattedShortTime = '0:00';
+        $timeParts = explode(':', $time);
+        $hour = ltrim($timeParts[0], '0');
+        if ($hour === '') {
+            $hour = '0';
         }
-        return $formattedShortTime;
+        $timeParts[0] = $hour;
+        return implode(':', $timeParts);
     }
 
     private function formatSummary(string $calsum): string

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
+use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
@@ -49,17 +50,6 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
             . ucfirst($this->trans->getTranslations()->t('always_open'))
             . '</p>'
         );
-    }
-
-    private function getFormattedTime(string $time): string
-    {
-        $timeParts = explode(':', $time);
-        $hour = ltrim($timeParts[0], '0');
-        if ($hour === '') {
-            $hour = '0';
-        }
-        $timeParts[0] = $hour;
-        return implode(':', $timeParts);
     }
 
     private function formatSummary(string $calsum): string
@@ -133,10 +123,10 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
         foreach ($openingHoursData as $openingHours) {
             $daysOfWeek = $openingHours->getDaysOfWeek();
-            $firstOpens = $this->getFormattedTime($this->getEarliestTime($openingHoursData, $daysOfWeek));
-            $lastCloses = $this->getFormattedTime($this->getLatestTime($openingHoursData, $daysOfWeek));
-            $opens = $this->getFormattedTime($openingHours->getOpens());
-            $closes = $this->getFormattedTime($openingHours->getCloses());
+            $firstOpens = OpeningHourFormatter::format($this->getEarliestTime($openingHoursData, $daysOfWeek));
+            $lastCloses = OpeningHourFormatter::format($this->getLatestTime($openingHoursData, $daysOfWeek));
+            $opens = OpeningHourFormatter::format($openingHours->getOpens());
+            $closes = OpeningHourFormatter::format($openingHours->getCloses());
 
             foreach ($daysOfWeek as $dayOfWeek) {
                 $daySpanShort = ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek(

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
+use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
@@ -47,17 +48,6 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
         return ucfirst($this->trans->getTranslations()->t('always_open')) . PHP_EOL;
     }
 
-    private function getFormattedTime(string $time): string
-    {
-        $timeParts = explode(':', $time);
-        $hour = ltrim($timeParts[0], '0');
-        if ($hour === '') {
-            $hour = '0';
-        }
-        $timeParts[0] = $hour;
-        return implode(':', $timeParts);
-    }
-
     /**
      * @param OpeningHours[] $openingHoursData
      * @return string
@@ -76,15 +66,15 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
                 if (!isset($formattedDays[$dayOfWeek])) {
                     $formattedDays[$dayOfWeek] = ucfirst($translatedDay)
                         . ' ' . $this->trans->getTranslations()->t('from') . ' '
-                        . $this->getFormattedTime($openingHours->getOpens())
+                        . OpeningHourFormatter::format($openingHours->getOpens())
                         . ' ' . $this->trans->getTranslations()->t('till') . ' '
-                        . $this->getFormattedTime($openingHours->getCloses())
+                        . OpeningHourFormatter::format($openingHours->getCloses())
                         . PHP_EOL;
                 } else {
                     $formattedDays[$dayOfWeek] .= '' . $this->trans->getTranslations()->t('from') . ' '
-                        . $this->getFormattedTime($openingHours->getOpens())
+                        . OpeningHourFormatter::format($openingHours->getOpens())
                         . ' ' . $this->trans->getTranslations()->t('till') . ' '
-                        . $this->getFormattedTime($openingHours->getCloses())
+                        . OpeningHourFormatter::format($openingHours->getCloses())
                         . PHP_EOL;
                 }
             }

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -49,11 +49,13 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
 
     private function getFormattedTime(string $time): string
     {
-        $formattedShortTime = ltrim($time, '0');
-        if ($formattedShortTime == ':00') {
-            $formattedShortTime = '0:00';
+        $timeParts = explode(':', $time);
+        $hour = ltrim($timeParts[0], '0');
+        if ($hour === '') {
+            $hour = '0';
         }
-        return $formattedShortTime;
+        $timeParts[0] = $hour;
+        return implode(':', $timeParts);
     }
 
     /**

--- a/tests/Periodic/LargePeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/LargePeriodicHTMLFormatterTest.php
@@ -222,13 +222,13 @@ class LargePeriodicHTMLFormatterTest extends TestCase
 
         $openingHours3 = new OpeningHours();
         $openingHours3->setDaysOfWeek(['tuesday']);
-        $openingHours3->setOpens('18:00');
+        $openingHours3->setOpens('00:00');
         $openingHours3->setCloses('20:00');
 
         $openingHours4 = new OpeningHours();
         $openingHours4->setDaysOfWeek(['tuesday']);
-        $openingHours4->setOpens('21:00');
-        $openingHours4->setCloses('23:00');
+        $openingHours4->setOpens('00:01');
+        $openingHours4->setCloses('00:59');
 
         $openingHours5 = new OpeningHours();
         $openingHours5->setDaysOfWeek(['friday', 'saturday']);
@@ -270,14 +270,14 @@ class LargePeriodicHTMLFormatterTest extends TestCase
             .'<span class="cf-time">9:30</span> '
             .'<span itemprop="closes" content="13:45" class="cf-to cf-meta">tot</span> '
             .'<span class="cf-time">13:45</span> '
-            .'<span itemprop="opens" content="18:00" class="cf-from cf-meta">en van</span> '
-            .'<span class="cf-time">18:00</span> '
+            .'<span itemprop="opens" content="0:00" class="cf-from cf-meta">en van</span> '
+            .'<span class="cf-time">0:00</span> '
             .'<span itemprop="closes" content="20:00" class="cf-to cf-meta">tot</span> '
             .'<span class="cf-time">20:00</span> '
-            .'<span itemprop="opens" content="21:00" class="cf-from cf-meta">en van</span> '
-            .'<span class="cf-time">21:00</span> '
-            .'<span itemprop="closes" content="23:00" class="cf-to cf-meta">tot</span> '
-            .'<span class="cf-time">23:00</span> '
+            .'<span itemprop="opens" content="0:01" class="cf-from cf-meta">en van</span> '
+            .'<span class="cf-time">0:01</span> '
+            .'<span itemprop="closes" content="0:59" class="cf-to cf-meta">tot</span> '
+            .'<span class="cf-time">0:59</span> '
             .'</li> '
             .'<meta itemprop="openingHours" datetime="Vr 10:00-15:00"> </meta> '
             .'<li itemprop="openingHoursSpecification"> '

--- a/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
@@ -30,7 +30,7 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday', 'wednesday']);
-        $openingHours1->setOpens('00:00');
+        $openingHours1->setOpens('00:01');
         $openingHours1->setCloses('17:00');
 
         $openingHours2 = new OpeningHours();
@@ -44,9 +44,9 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
 
         $this->assertEquals(
             'Van 25 november 2025 tot 30 november 2030'. PHP_EOL
-            . '(maandag van 0:00 tot 17:00, '
-            . 'dinsdag van 0:00 tot 17:00, '
-            . 'woensdag van 0:00 tot 17:00, '
+            . '(maandag van 0:01 tot 17:00, '
+            . 'dinsdag van 0:01 tot 17:00, '
+            . 'woensdag van 0:01 tot 17:00, '
             . 'vrijdag van 10:00 tot 18:00, '
             . 'zaterdag van 10:00 tot 18:00)',
             $this->formatter->format($place)

--- a/tests/Permanent/LargePermanentHTMLFormatterTest.php
+++ b/tests/Permanent/LargePermanentHTMLFormatterTest.php
@@ -30,7 +30,7 @@ class LargePermanentHTMLFormatterTest extends TestCase
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday', 'wednesday']);
-        $openingHours1->setOpens('00:00');
+        $openingHours1->setOpens('00:01');
         $openingHours1->setCloses('13:00');
 
         $openingHours2 = new OpeningHours();
@@ -49,27 +49,27 @@ class LargePermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<ul class="list-unstyled"> '
-            .'<meta itemprop="openingHours" datetime="Ma 0:00-13:00"> </meta> '
+            .'<meta itemprop="openingHours" datetime="Ma 0:01-13:00"> </meta> '
             .'<li itemprop="openingHoursSpecification"> '
             .'<span class="cf-days">Maandag</span> '
-            .'<span itemprop="opens" content="0:00" class="cf-from cf-meta">van</span> '
-            .'<span class="cf-time">0:00</span> '
+            .'<span itemprop="opens" content="0:01" class="cf-from cf-meta">van</span> '
+            .'<span class="cf-time">0:01</span> '
             .'<span itemprop="closes" content="13:00" class="cf-to cf-meta">tot</span> '
             .'<span class="cf-time">13:00</span> '
             .'</li> '
-            .'<meta itemprop="openingHours" datetime="Di 0:00-13:00"> </meta> '
+            .'<meta itemprop="openingHours" datetime="Di 0:01-13:00"> </meta> '
             .'<li itemprop="openingHoursSpecification"> '
             .'<span class="cf-days">Dinsdag</span> '
-            .'<span itemprop="opens" content="0:00" class="cf-from cf-meta">van</span> '
-            .'<span class="cf-time">0:00</span> '
+            .'<span itemprop="opens" content="0:01" class="cf-from cf-meta">van</span> '
+            .'<span class="cf-time">0:01</span> '
             .'<span itemprop="closes" content="13:00" class="cf-to cf-meta">tot</span> '
             .'<span class="cf-time">13:00</span> '
             .'</li> '
-            .'<meta itemprop="openingHours" datetime="Wo 0:00-13:00"> </meta> '
+            .'<meta itemprop="openingHours" datetime="Wo 0:01-13:00"> </meta> '
             .'<li itemprop="openingHoursSpecification"> '
             .'<span class="cf-days">Woensdag</span> '
-            .'<span itemprop="opens" content="0:00" class="cf-from cf-meta">van</span> '
-            .'<span class="cf-time">0:00</span> '
+            .'<span itemprop="opens" content="0:01" class="cf-from cf-meta">van</span> '
+            .'<span class="cf-time">0:01</span> '
             .'<span itemprop="closes" content="13:00" class="cf-to cf-meta">tot</span> '
             .'<span class="cf-time">13:00</span> '
             .'</li> '

--- a/tests/Permanent/LargePermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/LargePermanentPlainTextFormatterTest.php
@@ -35,7 +35,7 @@ class LargePermanentPlainTextFormatterTest extends TestCase
 
         $openingHours2 = new OpeningHours();
         $openingHours2->setDaysOfWeek(['friday']);
-        $openingHours2->setOpens('00:00');
+        $openingHours2->setOpens('00:01');
         $openingHours2->setCloses('13:00');
 
         $openingHours3 = new OpeningHours();
@@ -53,7 +53,7 @@ class LargePermanentPlainTextFormatterTest extends TestCase
             . 'Di van 9:00 tot 13:00'. PHP_EOL
             . 'Wo van 9:00 tot 13:00' . PHP_EOL
             . 'Do gesloten'. PHP_EOL
-            . 'Vr van 0:00 tot 13:00' . PHP_EOL
+            . 'Vr van 0:01 tot 13:00' . PHP_EOL
             . 'Za van 9:00 tot 19:00' . PHP_EOL
             . 'Zo van 9:00 tot 19:00' . PHP_EOL,
             $this->formatter->format($place)


### PR DESCRIPTION
### Fixed

- Fixed opening hours between `0:01` and `0:59` being displayed as `:01` and `:59`