### PR TITLE
Refactor language code

### DIFF
--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -57,7 +57,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                 ],
             Offer::CALENDAR_TYPE_PERIODIC =>
                 [
-                    'lg' => new LargePeriodicHTMLFormatter($langCode),
+                    'lg' => new LargePeriodicHTMLFormatter($translator),
                     'md' => new MediumPeriodicHTMLFormatter($langCode),
                     'sm' => new SmallPeriodicHTMLFormatter($langCode),
                     'xs' => new ExtraSmallPeriodicHTMLFormatter($langCode),

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -31,8 +31,11 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
      */
     private $middleware;
 
-    public function __construct($langCode = 'nl_BE', $hidePastDates = false, $timeZone = 'Europe/Brussels')
-    {
+    public function __construct(
+        string $langCode = 'nl_BE',
+        bool $hidePastDates = false,
+        string $timeZone = 'Europe/Brussels'
+    ) {
         date_default_timezone_set($timeZone);
 
         $translator = new Translator($langCode);

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -65,9 +65,9 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
             Offer::CALENDAR_TYPE_PERMANENT =>
                 [
                     'lg' => new LargePermanentHTMLFormatter($translator),
-                    'md' => new MediumPermanentHTMLFormatter($langCode),
-                    'sm' => new MediumPermanentHTMLFormatter($langCode),
-                    'xs' => new MediumPermanentHTMLFormatter($langCode)
+                    'md' => new MediumPermanentHTMLFormatter($translator),
+                    'sm' => new MediumPermanentHTMLFormatter($translator),
+                    'xs' => new MediumPermanentHTMLFormatter($translator)
                 ],
         ];
 

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -64,7 +64,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                 ],
             Offer::CALENDAR_TYPE_PERMANENT =>
                 [
-                    'lg' => new LargePermanentHTMLFormatter($langCode),
+                    'lg' => new LargePermanentHTMLFormatter($translator),
                     'md' => new MediumPermanentHTMLFormatter($langCode),
                     'sm' => new MediumPermanentHTMLFormatter($langCode),
                     'xs' => new MediumPermanentHTMLFormatter($langCode)

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -60,7 +60,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                     'lg' => new LargePeriodicHTMLFormatter($translator),
                     'md' => new MediumPeriodicHTMLFormatter($translator),
                     'sm' => new SmallPeriodicHTMLFormatter($translator),
-                    'xs' => new ExtraSmallPeriodicHTMLFormatter($langCode),
+                    'xs' => new ExtraSmallPeriodicHTMLFormatter($translator),
                 ],
             Offer::CALENDAR_TYPE_PERMANENT =>
                 [

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -43,14 +43,14 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
         $this->mapping = [
             Offer::CALENDAR_TYPE_SINGLE =>
                 [
-                    'lg' => new LargeSingleHTMLFormatter($langCode),
+                    'lg' => new LargeSingleHTMLFormatter($translator),
                     'md' => new MediumSingleHTMLFormatter($langCode),
                     'sm' => new SmallSingleHTMLFormatter($langCode),
                     'xs' => new SmallSingleHTMLFormatter($langCode)
                 ],
             Offer::CALENDAR_TYPE_MULTIPLE =>
                 [
-                    'lg' => new LargeMultipleHTMLFormatter($langCode, $hidePastDates),
+                    'lg' => new LargeMultipleHTMLFormatter($translator, $hidePastDates),
                     'md' => new MediumMultipleHTMLFormatter($langCode, $hidePastDates),
                     'sm' => new SmallMultipleHTMLFormatter($langCode),
                     'xs' => new ExtraSmallMultipleHTMLFormatter($langCode)

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -35,6 +35,9 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
     {
         date_default_timezone_set($timeZone);
 
+        $translator = new Translator();
+        $translator->setLanguage($langCode);
+
         $this->mapping = [
             Offer::CALENDAR_TYPE_SINGLE =>
                 [
@@ -66,7 +69,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                 ],
         ];
 
-        $this->middleware = new NonAvailablePlaceHTMLFormatter($langCode);
+        $this->middleware = new NonAvailablePlaceHTMLFormatter($translator);
     }
 
     /**

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -59,7 +59,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                 [
                     'lg' => new LargePeriodicHTMLFormatter($translator),
                     'md' => new MediumPeriodicHTMLFormatter($translator),
-                    'sm' => new SmallPeriodicHTMLFormatter($langCode),
+                    'sm' => new SmallPeriodicHTMLFormatter($translator),
                     'xs' => new ExtraSmallPeriodicHTMLFormatter($langCode),
                 ],
             Offer::CALENDAR_TYPE_PERMANENT =>

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -53,7 +53,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                     'lg' => new LargeMultipleHTMLFormatter($translator, $hidePastDates),
                     'md' => new MediumMultipleHTMLFormatter($translator, $hidePastDates),
                     'sm' => new SmallMultipleHTMLFormatter($langCode),
-                    'xs' => new ExtraSmallMultipleHTMLFormatter($langCode)
+                    'xs' => new ExtraSmallMultipleHTMLFormatter($translator)
                 ],
             Offer::CALENDAR_TYPE_PERIODIC =>
                 [

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -35,8 +35,7 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
     {
         date_default_timezone_set($timeZone);
 
-        $translator = new Translator();
-        $translator->setLanguage($langCode);
+        $translator = new Translator($langCode);
 
         $this->mapping = [
             Offer::CALENDAR_TYPE_SINGLE =>

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -45,8 +45,8 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                 [
                     'lg' => new LargeSingleHTMLFormatter($translator),
                     'md' => new MediumSingleHTMLFormatter($translator),
-                    'sm' => new SmallSingleHTMLFormatter($langCode),
-                    'xs' => new SmallSingleHTMLFormatter($langCode)
+                    'sm' => new SmallSingleHTMLFormatter($translator),
+                    'xs' => new SmallSingleHTMLFormatter($translator)
                 ],
             Offer::CALENDAR_TYPE_MULTIPLE =>
                 [

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -52,13 +52,13 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
                 [
                     'lg' => new LargeMultipleHTMLFormatter($translator, $hidePastDates),
                     'md' => new MediumMultipleHTMLFormatter($translator, $hidePastDates),
-                    'sm' => new SmallMultipleHTMLFormatter($langCode),
+                    'sm' => new SmallMultipleHTMLFormatter($translator),
                     'xs' => new ExtraSmallMultipleHTMLFormatter($translator)
                 ],
             Offer::CALENDAR_TYPE_PERIODIC =>
                 [
                     'lg' => new LargePeriodicHTMLFormatter($translator),
-                    'md' => new MediumPeriodicHTMLFormatter($langCode),
+                    'md' => new MediumPeriodicHTMLFormatter($translator),
                     'sm' => new SmallPeriodicHTMLFormatter($langCode),
                     'xs' => new ExtraSmallPeriodicHTMLFormatter($langCode),
                 ],

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -44,14 +44,14 @@ final class CalendarHTMLFormatter implements CalendarFormatterInterface
             Offer::CALENDAR_TYPE_SINGLE =>
                 [
                     'lg' => new LargeSingleHTMLFormatter($translator),
-                    'md' => new MediumSingleHTMLFormatter($langCode),
+                    'md' => new MediumSingleHTMLFormatter($translator),
                     'sm' => new SmallSingleHTMLFormatter($langCode),
                     'xs' => new SmallSingleHTMLFormatter($langCode)
                 ],
             Offer::CALENDAR_TYPE_MULTIPLE =>
                 [
                     'lg' => new LargeMultipleHTMLFormatter($translator, $hidePastDates),
-                    'md' => new MediumMultipleHTMLFormatter($langCode, $hidePastDates),
+                    'md' => new MediumMultipleHTMLFormatter($translator, $hidePastDates),
                     'sm' => new SmallMultipleHTMLFormatter($langCode),
                     'xs' => new ExtraSmallMultipleHTMLFormatter($langCode)
                 ],

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -35,6 +35,9 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
     {
         date_default_timezone_set($timeZone);
 
+        $translator = new Translator();
+        $translator->setLanguage($langCode);
+
         $this->mapping = [
             Offer::CALENDAR_TYPE_SINGLE =>
                 [
@@ -66,7 +69,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 ],
         ];
 
-        $this->middleware = new NonAvailablePlacePlainTextFormatter($langCode);
+        $this->middleware = new NonAvailablePlacePlainTextFormatter($translator);
     }
 
     /**

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -43,14 +43,14 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
         $this->mapping = [
             Offer::CALENDAR_TYPE_SINGLE =>
                 [
-                    'lg' => new LargeSinglePlainTextFormatter($langCode),
+                    'lg' => new LargeSinglePlainTextFormatter($translator),
                     'md' => new MediumSinglePlainTextFormatter($langCode),
                     'sm' => new SmallSinglePlainTextFormatter($langCode),
                     'xs' => new SmallSinglePlainTextFormatter($langCode)
                 ],
             Offer::CALENDAR_TYPE_MULTIPLE =>
                 [
-                    'lg' => new LargeMultiplePlainTextFormatter($langCode, $hidePastDates),
+                    'lg' => new LargeMultiplePlainTextFormatter($translator, $hidePastDates),
                     'md' => new MediumMultiplePlainTextFormatter($langCode, $hidePastDates),
                     'sm' => new SmallMultiplePlainTextFormatter($langCode),
                     'xs' => new ExtraSmallMultiplePlainTextFormatter($langCode)

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -35,8 +35,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
     {
         date_default_timezone_set($timeZone);
 
-        $translator = new Translator();
-        $translator->setLanguage($langCode);
+        $translator = new Translator($langCode);
 
         $this->mapping = [
             Offer::CALENDAR_TYPE_SINGLE =>

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -44,14 +44,14 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
             Offer::CALENDAR_TYPE_SINGLE =>
                 [
                     'lg' => new LargeSinglePlainTextFormatter($translator),
-                    'md' => new MediumSinglePlainTextFormatter($langCode),
+                    'md' => new MediumSinglePlainTextFormatter($translator),
                     'sm' => new SmallSinglePlainTextFormatter($langCode),
                     'xs' => new SmallSinglePlainTextFormatter($langCode)
                 ],
             Offer::CALENDAR_TYPE_MULTIPLE =>
                 [
                     'lg' => new LargeMultiplePlainTextFormatter($translator, $hidePastDates),
-                    'md' => new MediumMultiplePlainTextFormatter($langCode, $hidePastDates),
+                    'md' => new MediumMultiplePlainTextFormatter($translator, $hidePastDates),
                     'sm' => new SmallMultiplePlainTextFormatter($langCode),
                     'xs' => new ExtraSmallMultiplePlainTextFormatter($langCode)
                 ],

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -31,8 +31,11 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
      */
     private $middleware;
 
-    public function __construct($langCode = 'nl_BE', $hidePastDates = false, $timeZone = 'Europe/Brussels')
-    {
+    public function __construct(
+        string $langCode = 'nl_BE',
+        bool $hidePastDates = false,
+        string $timeZone = 'Europe/Brussels'
+    ) {
         date_default_timezone_set($timeZone);
 
         $translator = new Translator($langCode);

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -64,7 +64,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 ],
             Offer::CALENDAR_TYPE_PERMANENT =>
                 [
-                    'lg' => new LargePermanentPlainTextFormatter($langCode),
+                    'lg' => new LargePermanentPlainTextFormatter($translator),
                     'md' => new MediumPermanentPlainTextFormatter($langCode),
                     'sm' => new MediumPermanentPlainTextFormatter($langCode),
                     'xs' => new MediumPermanentPlainTextFormatter($langCode)

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -65,9 +65,9 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
             Offer::CALENDAR_TYPE_PERMANENT =>
                 [
                     'lg' => new LargePermanentPlainTextFormatter($translator),
-                    'md' => new MediumPermanentPlainTextFormatter($langCode),
-                    'sm' => new MediumPermanentPlainTextFormatter($langCode),
-                    'xs' => new MediumPermanentPlainTextFormatter($langCode)
+                    'md' => new MediumPermanentPlainTextFormatter($translator),
+                    'sm' => new MediumPermanentPlainTextFormatter($translator),
+                    'xs' => new MediumPermanentPlainTextFormatter($translator)
                 ],
         ];
 

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -57,7 +57,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 ],
             Offer::CALENDAR_TYPE_PERIODIC =>
                 [
-                    'lg' => new LargePeriodicPlainTextFormatter($langCode),
+                    'lg' => new LargePeriodicPlainTextFormatter($translator),
                     'md' => new MediumPeriodicPlainTextFormatter($translator),
                     'sm' => new SmallPeriodicPlainTextFormatter($langCode),
                     'xs' => new ExtraSmallPeriodicPlainTextFormatter($langCode),

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -59,7 +59,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 [
                     'lg' => new LargePeriodicPlainTextFormatter($translator),
                     'md' => new MediumPeriodicPlainTextFormatter($translator),
-                    'sm' => new SmallPeriodicPlainTextFormatter($langCode),
+                    'sm' => new SmallPeriodicPlainTextFormatter($translator),
                     'xs' => new ExtraSmallPeriodicPlainTextFormatter($langCode),
                 ],
             Offer::CALENDAR_TYPE_PERMANENT =>

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -53,7 +53,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                     'lg' => new LargeMultiplePlainTextFormatter($translator, $hidePastDates),
                     'md' => new MediumMultiplePlainTextFormatter($translator, $hidePastDates),
                     'sm' => new SmallMultiplePlainTextFormatter($translator),
-                    'xs' => new ExtraSmallMultiplePlainTextFormatter($langCode)
+                    'xs' => new ExtraSmallMultiplePlainTextFormatter($translator)
                 ],
             Offer::CALENDAR_TYPE_PERIODIC =>
                 [

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -45,8 +45,8 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 [
                     'lg' => new LargeSinglePlainTextFormatter($translator),
                     'md' => new MediumSinglePlainTextFormatter($translator),
-                    'sm' => new SmallSinglePlainTextFormatter($langCode),
-                    'xs' => new SmallSinglePlainTextFormatter($langCode)
+                    'sm' => new SmallSinglePlainTextFormatter($translator),
+                    'xs' => new SmallSinglePlainTextFormatter($translator)
                 ],
             Offer::CALENDAR_TYPE_MULTIPLE =>
                 [

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -52,13 +52,13 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 [
                     'lg' => new LargeMultiplePlainTextFormatter($translator, $hidePastDates),
                     'md' => new MediumMultiplePlainTextFormatter($translator, $hidePastDates),
-                    'sm' => new SmallMultiplePlainTextFormatter($langCode),
+                    'sm' => new SmallMultiplePlainTextFormatter($translator),
                     'xs' => new ExtraSmallMultiplePlainTextFormatter($langCode)
                 ],
             Offer::CALENDAR_TYPE_PERIODIC =>
                 [
                     'lg' => new LargePeriodicPlainTextFormatter($langCode),
-                    'md' => new MediumPeriodicPlainTextFormatter($langCode),
+                    'md' => new MediumPeriodicPlainTextFormatter($translator),
                     'sm' => new SmallPeriodicPlainTextFormatter($langCode),
                     'xs' => new ExtraSmallPeriodicPlainTextFormatter($langCode),
                 ],

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -60,7 +60,7 @@ final class CalendarPlainTextFormatter implements CalendarFormatterInterface
                     'lg' => new LargePeriodicPlainTextFormatter($translator),
                     'md' => new MediumPeriodicPlainTextFormatter($translator),
                     'sm' => new SmallPeriodicPlainTextFormatter($translator),
-                    'xs' => new ExtraSmallPeriodicPlainTextFormatter($langCode),
+                    'xs' => new ExtraSmallPeriodicPlainTextFormatter($translator),
                 ],
             Offer::CALENDAR_TYPE_PERMANENT =>
                 [

--- a/src/Middleware/NonAvailablePlaceHTMLFormatter.php
+++ b/src/Middleware/NonAvailablePlaceHTMLFormatter.php
@@ -14,27 +14,27 @@ class NonAvailablePlaceHTMLFormatter implements FormatterMiddleware
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
     public function __construct(
-        string $langCode
+        Translator $translator
     ) {
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->translator = $translator;
     }
+
 
     public function format(Offer $offer, Closure $next): string
     {
         if ($offer instanceof Place) {
             if ($offer->getStatus()->getType() === 'Unavailable') {
                 return $this->wrapInTag(
-                    $this->trans->getTranslations()->t('permanently_closed')
+                    $this->translator->getTranslations()->t('permanently_closed')
                 );
             }
 
             if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
                 return $this->wrapInTag(
-                    $this->trans->getTranslations()->t('temporarily_closed')
+                    $this->translator->getTranslations()->t('temporarily_closed')
                 );
             }
         }

--- a/src/Middleware/NonAvailablePlaceHTMLFormatter.php
+++ b/src/Middleware/NonAvailablePlaceHTMLFormatter.php
@@ -28,13 +28,13 @@ class NonAvailablePlaceHTMLFormatter implements FormatterMiddleware
         if ($offer instanceof Place) {
             if ($offer->getStatus()->getType() === 'Unavailable') {
                 return $this->wrapInTag(
-                    $this->translator->getTranslations()->t('permanently_closed')
+                    $this->translator->translate('permanently_closed')
                 );
             }
 
             if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
                 return $this->wrapInTag(
-                    $this->translator->getTranslations()->t('temporarily_closed')
+                    $this->translator->translate('temporarily_closed')
                 );
             }
         }

--- a/src/Middleware/NonAvailablePlacePlainTextFormatter.php
+++ b/src/Middleware/NonAvailablePlacePlainTextFormatter.php
@@ -26,11 +26,11 @@ class NonAvailablePlacePlainTextFormatter implements FormatterMiddleware
     {
         if ($offer instanceof Place) {
             if ($offer->getStatus()->getType() === 'Unavailable') {
-                return $this->translator->getTranslations()->t('permanently_closed');
+                return $this->translator->translate('permanently_closed');
             }
 
             if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
-                return $this->translator->getTranslations()->t('temporarily_closed');
+                return $this->translator->translate('temporarily_closed');
             }
         }
 

--- a/src/Middleware/NonAvailablePlacePlainTextFormatter.php
+++ b/src/Middleware/NonAvailablePlacePlainTextFormatter.php
@@ -14,24 +14,23 @@ class NonAvailablePlacePlainTextFormatter implements FormatterMiddleware
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
     public function __construct(
-        string $langCode
+        Translator $translator
     ) {
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer, Closure $next): string
     {
         if ($offer instanceof Place) {
             if ($offer->getStatus()->getType() === 'Unavailable') {
-                return $this->trans->getTranslations()->t('permanently_closed');
+                return $this->translator->getTranslations()->t('permanently_closed');
             }
 
             if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
-                return $this->trans->getTranslations()->t('temporarily_closed');
+                return $this->translator->getTranslations()->t('temporarily_closed');
             }
         }
 

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -18,12 +18,12 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Event $event): string
@@ -35,9 +35,9 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
             return '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span>';
         }
 
-        return '<span class="cf-from cf-meta">' . ucfirst($this->trans->getTranslations()->t('from')) . '</span> ' .
+        return '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span> ' .
             '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span> ' .
-            '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till') . '</span> '.
+            '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span> '.
             '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateTo) . '</span>';
     }
 }

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -23,8 +23,7 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Event $event): string

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -35,9 +35,9 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
             return '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span>';
         }
 
-        return '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span> ' .
+        return '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span> ' .
             '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span> ' .
-            '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span> '.
+            '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span> '.
             '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateTo) . '</span>';
     }
 }

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -24,8 +24,7 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Event $event): string

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -19,12 +19,12 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Event $event): string
@@ -36,7 +36,7 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
             return $this->formatter->formatAsShortDate($startDate);
         }
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->from($this->formatter->formatAsShortDate($startDate))
             ->till($this->formatter->formatAsShortDate($endDate))
             ->toString();

--- a/src/Multiple/LargeMultipleHTMLFormatter.php
+++ b/src/Multiple/LargeMultipleHTMLFormatter.php
@@ -3,24 +3,25 @@
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\LargeSingleHTMLFormatter;
 
 final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
-     * @var string $langCode
+     * @var Translator
      */
-    private $langCode;
+    private $translator;
 
     /**
      * @var bool $hidePast
      */
     private $hidePast;
 
-    public function __construct(string $langCode, bool $hidePastDates)
+    public function __construct(Translator $translator, bool $hidePastDates)
     {
-        $this->langCode = $langCode;
+        $this->translator = $translator;
         $this->hidePast = $hidePastDates;
     }
 
@@ -30,7 +31,7 @@ final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
         $output = '<ul class="cnw-event-date-info">';
 
         foreach ($subEvents as $subEvent) {
-            $formatter = new LargeSingleHTMLFormatter($this->langCode);
+            $formatter = new LargeSingleHTMLFormatter($this->translator);
 
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
                 $output .= '<li>' . $formatter->format($subEvent) . '</li>';

--- a/src/Multiple/LargeMultipleHTMLFormatter.php
+++ b/src/Multiple/LargeMultipleHTMLFormatter.php
@@ -15,7 +15,7 @@ final class LargeMultipleHTMLFormatter implements MultipleFormatterInterface
     private $translator;
 
     /**
-     * @var bool $hidePast
+     * @var bool
      */
     private $hidePast;
 

--- a/src/Multiple/LargeMultiplePlainTextFormatter.php
+++ b/src/Multiple/LargeMultiplePlainTextFormatter.php
@@ -3,24 +3,25 @@
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\LargeSinglePlainTextFormatter;
 
 final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
-     * @var string $langCode
+     * @var Translator
      */
-    private $langCode;
+    private $translator;
 
     /**
      * @var bool $hidePast
      */
     private $hidePast;
 
-    public function __construct(string $langCode, bool $hidePastDates)
+    public function __construct(Translator $translator, bool $hidePastDates)
     {
-        $this->langCode = $langCode;
+        $this->translator = $translator;
         $this->hidePast = $hidePastDates;
     }
 
@@ -30,7 +31,7 @@ final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterfac
         $subEventSummaries = [];
 
         foreach ($subEvents as $key => $subEvent) {
-            $formatter = new LargeSinglePlainTextFormatter($this->langCode);
+            $formatter = new LargeSinglePlainTextFormatter($this->translator);
 
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
                 $subEventSummaries[] = $formatter->format($subEvent);

--- a/src/Multiple/LargeMultiplePlainTextFormatter.php
+++ b/src/Multiple/LargeMultiplePlainTextFormatter.php
@@ -15,7 +15,7 @@ final class LargeMultiplePlainTextFormatter implements MultipleFormatterInterfac
     private $translator;
 
     /**
-     * @var bool $hidePast
+     * @var bool
      */
     private $hidePast;
 

--- a/src/Multiple/MediumMultipleHTMLFormatter.php
+++ b/src/Multiple/MediumMultipleHTMLFormatter.php
@@ -3,24 +3,25 @@
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\MediumSingleHTMLFormatter;
 
 final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
-     * @var string $langCode
+     * @var Translator
      */
-    private $langCode;
+    private $translator;
 
     /**
      * @var bool $hidepast
      */
     private $hidePast;
 
-    public function __construct(string $langCode, bool $hidePastDates)
+    public function __construct(Translator $translator, bool $hidePastDates)
     {
-        $this->langCode = $langCode;
+        $this->translator = $translator;
         $this->hidePast = $hidePastDates;
     }
 
@@ -30,7 +31,7 @@ final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
         $output = '<ul class="cnw-event-date-info">';
 
         foreach ($subEvents as $subEvent) {
-            $formatter = new MediumSingleHTMLFormatter($this->langCode);
+            $formatter = new MediumSingleHTMLFormatter($this->translator);
 
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
                 $output .= '<li>' . $formatter->format($subEvent) . '</li>';

--- a/src/Multiple/MediumMultipleHTMLFormatter.php
+++ b/src/Multiple/MediumMultipleHTMLFormatter.php
@@ -15,7 +15,7 @@ final class MediumMultipleHTMLFormatter implements MultipleFormatterInterface
     private $translator;
 
     /**
-     * @var bool $hidepast
+     * @var bool
      */
     private $hidePast;
 

--- a/src/Multiple/MediumMultiplePlainTextFormatter.php
+++ b/src/Multiple/MediumMultiplePlainTextFormatter.php
@@ -3,24 +3,25 @@
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\CalendarSummaryV3\Single\MediumSinglePlainTextFormatter;
 
 final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
-     * @var string $langCode
+     * @var Translator
      */
-    private $langCode;
+    private $translator;
 
     /**
      * @var bool $hidepast
      */
     private $hidePast;
 
-    public function __construct(string $langCode, bool $hidePastDates)
+    public function __construct(Translator $translator, bool $hidePastDates)
     {
-        $this->langCode = $langCode;
+        $this->translator = $translator;
         $this->hidePast = $hidePastDates;
     }
 
@@ -30,7 +31,7 @@ final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterfa
         $subEventSummaries = [];
 
         foreach ($subEvents as $key => $subEvent) {
-            $formatter = new MediumSinglePlainTextFormatter($this->langCode);
+            $formatter = new MediumSinglePlainTextFormatter($this->translator);
 
             if (!$this->hidePast || DateComparison::inTheFuture($subEvent->getEndDate())) {
                 $subEventSummaries[] = $formatter->format($subEvent);

--- a/src/Multiple/MediumMultiplePlainTextFormatter.php
+++ b/src/Multiple/MediumMultiplePlainTextFormatter.php
@@ -15,7 +15,7 @@ final class MediumMultiplePlainTextFormatter implements MultipleFormatterInterfa
     private $translator;
 
     /**
-     * @var bool $hidepast
+     * @var bool
      */
     private $hidePast;
 

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -3,23 +3,24 @@
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicHTMLFormatter;
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 
 final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
 {
     /**
-     * @var string
+     * @var Translator
      */
-    private $langCode;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->langCode = $langCode;
+        $this->translator = $translator;
     }
 
     public function format(Event $event): string
     {
-        $formatter = new MediumPeriodicHTMLFormatter($this->langCode);
+        $formatter = new MediumPeriodicHTMLFormatter($this->translator);
         return $formatter->format($event);
     }
 }

--- a/src/Multiple/SmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/SmallMultiplePlainTextFormatter.php
@@ -3,23 +3,24 @@
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicPlainTextFormatter;
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 
 final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
     /**
-     * @var string
+     * @var Translator
      */
-    private $langCode;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->langCode = $langCode;
+        $this->translator = $translator;
     }
 
     public function format(Event $event): string
     {
-        $formatter = new MediumPeriodicPlainTextFormatter($this->langCode);
+        $formatter = new MediumPeriodicPlainTextFormatter($this->translator);
         return $formatter->format($event);
     }
 }

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -25,8 +25,7 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
     {
         $this->formatter = new DateFormatter($langCode);
 
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -19,13 +19,12 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -44,14 +43,14 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
     private function formatStarted(DateTimeInterface $endDate): string
     {
         return
-            '<span class="to meta">' . ucfirst($this->trans->getTranslations()->t('till')) . '</span> ' .
+            '<span class="to meta">' . ucfirst($this->translator->getTranslations()->t('till')) . '</span> ' .
             $this->formatDate($endDate);
     }
 
     private function formatNotStarted(DateTimeInterface $startDate): string
     {
         return
-            '<span class="from meta">' . ucfirst($this->trans->getTranslations()->t('from_period')) . '</span> ' .
+            '<span class="from meta">' . ucfirst($this->translator->getTranslations()->t('from_period')) . '</span> ' .
             $this->formatDate($startDate);
     }
 

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -43,14 +43,14 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
     private function formatStarted(DateTimeInterface $endDate): string
     {
         return
-            '<span class="to meta">' . ucfirst($this->translator->getTranslations()->t('till')) . '</span> ' .
+            '<span class="to meta">' . ucfirst($this->translator->translate('till')) . '</span> ' .
             $this->formatDate($endDate);
     }
 
     private function formatNotStarted(DateTimeInterface $startDate): string
     {
         return
-            '<span class="from meta">' . ucfirst($this->translator->getTranslations()->t('from_period')) . '</span> ' .
+            '<span class="from meta">' . ucfirst($this->translator->translate('from_period')) . '</span> ' .
             $this->formatDate($startDate);
     }
 

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -26,8 +26,7 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
     {
         $this->formatter = new DateFormatter($langCode);
 
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -20,13 +20,12 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -44,14 +43,14 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
 
     private function formatStarted(DateTimeInterface $endDate): string
     {
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->till($this->formatter->formatAsShortDate($endDate))
             ->toString();
     }
 
     private function formatNotStarted(DateTimeInterface $startDate): string
     {
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->fromPeriod($this->formatter->formatAsShortDate($startDate))
             ->toString();
     }

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -105,7 +105,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
         return '<p class="cf-period">'
             . '<time itemprop="startDate" datetime="' . $dateFrom->format("Y-m-d") . '">'
             . '<span class="cf-date">' . $intlDateFrom . '</span> </time>'
-            . '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>'
+            . '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>'
             . '<time itemprop="endDate" datetime="' . $dateTo->format("Y-m-d") . '">'
             . '<span class="cf-date">' . $intlDateTo . '</span> </time>'
             . '</p>';
@@ -117,7 +117,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      */
     private function generateWeekScheme($openingHoursData)
     {
-        $outputWeek = '<p class="cf-openinghours">' . ucfirst($this->translator->getTranslations()->t('open')) . ':</p>';
+        $outputWeek = '<p class="cf-openinghours">' . ucfirst($this->translator->translate('open')) . ':</p>';
         $outputWeek .= '<ul class="list-unstyled">';
 
         // Create an array with formatted timespans.
@@ -145,19 +145,19 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
                         . "<li itemprop=\"openingHoursSpecification\"> "
                         . "<span class=\"cf-days\">$daySpanLong</span> "
                         . "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->translator->getTranslations()->t('from') . "</span> "
+                        . $this->translator->translate('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->translator->getTranslations()->t('till') . "</span> "
+                        . $this->translator->translate('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 } else {
                     $formattedTimespans[$dayOfWeek] .=
                         "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->translator->getTranslations()->t('and') . ' '
-                        . $this->translator->getTranslations()->t('from') . "</span> "
+                        . $this->translator->translate('and') . ' '
+                        . $this->translator->translate('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->translator->getTranslations()->t('till') . "</span> "
+                        . $this->translator->translate('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 }
             }

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -26,8 +26,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
     {
         $this->formatter = new DateFormatter($langCode);
 
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -20,13 +20,12 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -106,7 +105,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
         return '<p class="cf-period">'
             . '<time itemprop="startDate" datetime="' . $dateFrom->format("Y-m-d") . '">'
             . '<span class="cf-date">' . $intlDateFrom . '</span> </time>'
-            . '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till') . '</span>'
+            . '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>'
             . '<time itemprop="endDate" datetime="' . $dateTo->format("Y-m-d") . '">'
             . '<span class="cf-date">' . $intlDateTo . '</span> </time>'
             . '</p>';
@@ -118,7 +117,7 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
      */
     private function generateWeekScheme($openingHoursData)
     {
-        $outputWeek = '<p class="cf-openinghours">' . ucfirst($this->trans->getTranslations()->t('open')) . ':</p>';
+        $outputWeek = '<p class="cf-openinghours">' . ucfirst($this->translator->getTranslations()->t('open')) . ':</p>';
         $outputWeek .= '<ul class="list-unstyled">';
 
         // Create an array with formatted timespans.
@@ -146,19 +145,19 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
                         . "<li itemprop=\"openingHoursSpecification\"> "
                         . "<span class=\"cf-days\">$daySpanLong</span> "
                         . "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->trans->getTranslations()->t('from') . "</span> "
+                        . $this->translator->getTranslations()->t('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->trans->getTranslations()->t('till') . "</span> "
+                        . $this->translator->getTranslations()->t('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 } else {
                     $formattedTimespans[$dayOfWeek] .=
                         "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->trans->getTranslations()->t('and') . ' '
-                        . $this->trans->getTranslations()->t('from') . "</span> "
+                        . $this->translator->getTranslations()->t('and') . ' '
+                        . $this->translator->getTranslations()->t('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->trans->getTranslations()->t('till') . "</span> "
+                        . $this->translator->getTranslations()->t('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 }
             }

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -26,9 +26,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -55,8 +55,8 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         $intlDateFrom = $this->formatter->formatAsFullDate($dateFrom);
         $intlDateTo = $this->formatter->formatAsFullDate($dateTo);
 
-        return ucfirst($this->translator->getTranslations()->t('from')) . ' '
-            . $intlDateFrom . ' ' . $this->translator->getTranslations()->t('till') . ' ' . $intlDateTo;
+        return ucfirst($this->translator->translate('from')) . ' '
+            . $intlDateFrom . ' ' . $this->translator->translate('till') . ' ' . $intlDateTo;
     }
 
     /**

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -21,12 +21,12 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -37,7 +37,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         $formattedStartDate = $this->formatter->formatAsFullDate($startDate);
         $formattedEndDate = $this->formatter->formatAsFullDate($endDate);
 
-        $summary = PlainTextSummaryBuilder::start($this->trans)
+        $summary = PlainTextSummaryBuilder::start($this->translator)
             ->from($formattedStartDate)
             ->till($formattedEndDate);
 
@@ -55,8 +55,8 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         $intlDateFrom = $this->formatter->formatAsFullDate($dateFrom);
         $intlDateTo = $this->formatter->formatAsFullDate($dateTo);
 
-        return ucfirst($this->trans->getTranslations()->t('from')) . ' '
-            . $intlDateFrom . ' ' . $this->trans->getTranslations()->t('till') . ' ' . $intlDateTo;
+        return ucfirst($this->translator->getTranslations()->t('from')) . ' '
+            . $intlDateFrom . ' ' . $this->translator->getTranslations()->t('till') . ' ' . $intlDateTo;
     }
 
     /**
@@ -73,7 +73,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
                 if (!isset($formattedDays[$dayName])) {
                     $translatedDay = $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($dayName));
 
-                    $formattedDays[$dayName] = PlainTextSummaryBuilder::start($this->trans)
+                    $formattedDays[$dayName] = PlainTextSummaryBuilder::start($this->translator)
                         ->lowercaseNextFirstCharacter()
                         ->append($translatedDay)
                         ->from(OpeningHourFormatter::format($openingHours->getOpens()))

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -16,12 +16,12 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -39,9 +39,9 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
                 . '<span class="cf-date">' . $intlDateFrom . '</span>';
         }
 
-        return '<span class="cf-from cf-meta">' . ucfirst($this->trans->getTranslations()->t('from'))
+        return '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from'))
             . '</span> <span class="cf-date">' . $intlDateFrom . '</span> '
-            . '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till')
+            . '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till')
             . '</span> <span class="cf-date">'. $intlDateTo . '</span>';
     }
 }

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -39,9 +39,9 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
                 . '<span class="cf-date">' . $intlDateFrom . '</span>';
         }
 
-        return '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from'))
+        return '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from'))
             . '</span> <span class="cf-date">' . $intlDateFrom . '</span> '
-            . '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till')
+            . '<span class="cf-to cf-meta">' . $this->translator->translate('till')
             . '</span> <span class="cf-date">'. $intlDateTo . '</span>';
     }
 }

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -21,9 +21,7 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -17,12 +17,12 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -38,7 +38,7 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
             return PlainTextSummaryBuilder::singleLine($formattedStartDayOfWeek, $formattedStartDate);
         }
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->from($formattedStartDate)
             ->till($formattedEndDate)
             ->toString();

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -22,9 +22,7 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -19,12 +19,12 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -43,14 +43,14 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
     private function formatStarted(DateTimeInterface $endDate): string
     {
         return
-            '<span class="to meta">' . ucfirst($this->trans->getTranslations()->t('till')) . '</span> ' .
+            '<span class="to meta">' . ucfirst($this->translator->getTranslations()->t('till')) . '</span> ' .
             $this->formatDate($endDate);
     }
 
     private function formatNotStarted(DateTimeInterface $startDate): string
     {
         return
-            '<span class="from meta">' . ucfirst($this->trans->getTranslations()->t('from_period')) . '</span> ' .
+            '<span class="from meta">' . ucfirst($this->translator->getTranslations()->t('from_period')) . '</span> ' .
             $this->formatDate($startDate);
     }
 

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -24,9 +24,7 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -43,14 +43,14 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
     private function formatStarted(DateTimeInterface $endDate): string
     {
         return
-            '<span class="to meta">' . ucfirst($this->translator->getTranslations()->t('till')) . '</span> ' .
+            '<span class="to meta">' . ucfirst($this->translator->translate('till')) . '</span> ' .
             $this->formatDate($endDate);
     }
 
     private function formatNotStarted(DateTimeInterface $startDate): string
     {
         return
-            '<span class="from meta">' . ucfirst($this->translator->getTranslations()->t('from_period')) . '</span> ' .
+            '<span class="from meta">' . ucfirst($this->translator->translate('from_period')) . '</span> ' .
             $this->formatDate($startDate);
     }
 

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -20,12 +20,12 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -43,14 +43,14 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
 
     private function formatStarted(DateTimeInterface $endDate): string
     {
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->till($this->formatDate($endDate))
             ->toString();
     }
 
     private function formatNotStarted(DateTimeInterface $startDate): string
     {
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->fromPeriod($this->formatDate($startDate))
             ->toString();
     }

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -25,9 +25,7 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -34,9 +34,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -29,12 +29,12 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -45,7 +45,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
         return $this->formatSummary(
             '<p class="cf-openinghours">'
-            . ucfirst($this->trans->getTranslations()->t('always_open'))
+            . ucfirst($this->translator->getTranslations()->t('always_open'))
             . '</p>'
         );
     }
@@ -103,10 +103,10 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     private function generateFormattedTimespan(string $dayOfWeek, bool $long = false): string
     {
         if ($long) {
-            return ucfirst($this->trans->getTranslations()->t($dayOfWeek));
+            return ucfirst($this->translator->getTranslations()->t($dayOfWeek));
         } else {
             //return ucfirst($this->mappingShortDays[$dayOfWeek]);
-            return ucfirst($this->trans->getTranslations()->t($dayOfWeek . 'Short'));
+            return ucfirst($this->translator->getTranslations()->t($dayOfWeek . 'Short'));
         }
     }
 
@@ -139,18 +139,18 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
                         . "<li itemprop=\"openingHoursSpecification\"> "
                         . "<span class=\"cf-days\">$daySpanLong</span> "
                         . "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->trans->getTranslations()->t('from') . "</span> "
+                        . $this->translator->getTranslations()->t('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->trans->getTranslations()->t('till') . "</span> "
+                        . $this->translator->getTranslations()->t('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 } else {
                     $formattedTimespans[$dayOfWeek] .=
                         "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->trans->getTranslations()->t('from') . "</span> "
+                        . $this->translator->getTranslations()->t('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->trans->getTranslations()->t('till') . "</span> "
+                        . $this->translator->getTranslations()->t('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 }
             }
@@ -175,7 +175,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
                     . "<li itemprop=\"openingHoursSpecification\"> "
                     . "<span class=\"cf-days\">$closedDays[$day]</span> "
                     . "<span itemprop=\"closed\" content=\"closed\" class=\"cf-closed cf-meta\">"
-                    . $this->trans->getTranslations()->t('closed') . "</span> ";
+                    . $this->translator->getTranslations()->t('closed') . "</span> ";
             }
         }
 

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -45,7 +45,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
         return $this->formatSummary(
             '<p class="cf-openinghours">'
-            . ucfirst($this->translator->getTranslations()->t('always_open'))
+            . ucfirst($this->translator->translate('always_open'))
             . '</p>'
         );
     }
@@ -103,10 +103,10 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
     private function generateFormattedTimespan(string $dayOfWeek, bool $long = false): string
     {
         if ($long) {
-            return ucfirst($this->translator->getTranslations()->t($dayOfWeek));
+            return ucfirst($this->translator->translate($dayOfWeek));
         } else {
             //return ucfirst($this->mappingShortDays[$dayOfWeek]);
-            return ucfirst($this->translator->getTranslations()->t($dayOfWeek . 'Short'));
+            return ucfirst($this->translator->translate($dayOfWeek . 'Short'));
         }
     }
 
@@ -139,18 +139,18 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
                         . "<li itemprop=\"openingHoursSpecification\"> "
                         . "<span class=\"cf-days\">$daySpanLong</span> "
                         . "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->translator->getTranslations()->t('from') . "</span> "
+                        . $this->translator->translate('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->translator->getTranslations()->t('till') . "</span> "
+                        . $this->translator->translate('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 } else {
                     $formattedTimespans[$dayOfWeek] .=
                         "<span itemprop=\"opens\" content=\"$opens\" class=\"cf-from cf-meta\">"
-                        . $this->translator->getTranslations()->t('from') . "</span> "
+                        . $this->translator->translate('from') . "</span> "
                         . "<span class=\"cf-time\">$opens</span> "
                         . "<span itemprop=\"closes\" content=\"$closes\" class=\"cf-to cf-meta\">"
-                        . $this->translator->getTranslations()->t('till') . "</span> "
+                        . $this->translator->translate('till') . "</span> "
                         . "<span class=\"cf-time\">$closes</span>";
                 }
             }
@@ -175,7 +175,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
                     . "<li itemprop=\"openingHoursSpecification\"> "
                     . "<span class=\"cf-days\">$closedDays[$day]</span> "
                     . "<span itemprop=\"closed\" content=\"closed\" class=\"cf-closed cf-meta\">"
-                    . $this->translator->getTranslations()->t('closed') . "</span> ";
+                    . $this->translator->translate('closed') . "</span> ";
             }
         }
 

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -20,12 +20,12 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -34,7 +34,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
             return $this->generateWeekScheme($offer->getOpeningHours());
         }
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->alwaysOpen()
             ->startNewLine()
             ->toString();
@@ -59,7 +59,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
         // Add day name to the start of each day's week scheme
         $formattedDays = [];
         foreach ($dayNames as $dayName) {
-            $formattedDays[$dayName] = PlainTextSummaryBuilder::start($this->trans)
+            $formattedDays[$dayName] = PlainTextSummaryBuilder::start($this->translator)
                 ->append($this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName)));
         }
 

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -25,9 +25,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -23,9 +23,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -18,12 +18,12 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -33,7 +33,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
         }
 
         return '<p class="cf-openinghours">' .
-            ucfirst($this->trans->getTranslations()->t('always_open')) . '</p>';
+            ucfirst($this->translator->getTranslations()->t('always_open')) . '</p>';
     }
 
     /**
@@ -44,7 +44,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
      */
     private function generateWeekScheme(array $openingHoursData): string
     {
-        $outputWeek = '<span>' . ucfirst($this->trans->getTranslations()->t('open')) . ' '
+        $outputWeek = '<span>' . ucfirst($this->translator->getTranslations()->t('open')) . ' '
             . '<span class="cf-weekdays">';
         // Create an array with formatted days.
         $formattedDays = [];

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -33,7 +33,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
         }
 
         return '<p class="cf-openinghours">' .
-            ucfirst($this->translator->getTranslations()->t('always_open')) . '</p>';
+            ucfirst($this->translator->translate('always_open')) . '</p>';
     }
 
     /**
@@ -44,7 +44,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
      */
     private function generateWeekScheme(array $openingHoursData): string
     {
-        $outputWeek = '<span>' . ucfirst($this->translator->getTranslations()->t('open')) . ' '
+        $outputWeek = '<span>' . ucfirst($this->translator->translate('open')) . ' '
             . '<span class="cf-weekdays">';
         // Create an array with formatted days.
         $formattedDays = [];

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -24,9 +24,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -19,12 +19,12 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -33,7 +33,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
             return $this->generateWeekScheme($offer->getOpeningHours());
         }
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->alwaysOpen()
             ->startNewLine()
             ->toString();
@@ -57,7 +57,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
 
         // Put all the day names with opening hours on a single line with 'Open at' (sec) at the beginning.
         // E.g. 'Open at monday, wednesday, thursday'
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->openAt(...$translatedDayNamesWithOpeningHours)
             ->toString();
     }

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -123,7 +123,7 @@ final class PlainTextSummaryBuilder
     private function appendTranslation(string $translationKey): self
     {
         $c = clone $this;
-        $c->workingLine[] = $this->translator->getTranslations()->t($translationKey);
+        $c->workingLine[] = $this->translator->translate($translationKey);
         return $c;
     }
 

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -18,12 +18,12 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -61,7 +61,7 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
                 . ' '
                 . '<span class="cf-date">' . $intlDateFrom . '</span>'
                 . ' '
-                . '<span class="cf-from cf-meta">' . $this->trans->getTranslations()->t('at') . '</span>'
+                . '<span class="cf-from cf-meta">' . $this->translator->getTranslations()->t('at') . '</span>'
                 . ' '
                 . '<span class="cf-time">' . $intlStartTimeFrom . '</span>'
                 . '</time>';
@@ -72,12 +72,12 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
             . ' '
             . '<span class="cf-date">' . $intlDateFrom . '</span>'
             . ' '
-            . '<span class="cf-from cf-meta">' . $this->trans->getTranslations()->t('from') . '</span>'
+            . '<span class="cf-from cf-meta">' . $this->translator->getTranslations()->t('from') . '</span>'
             . ' '
             . '<span class="cf-time">' . $intlStartTimeFrom . '</span>'
             . '</time>'
             . ' '
-            . '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till') . '</span>'
+            . '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>'
             . ' '
             . '<time itemprop="endDate" datetime="' . $dateEnd->format(\DateTime::ATOM) . '">'
             . '<span class="cf-time">' . $intlEndTimeEnd . '</span>'
@@ -95,25 +95,25 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
         $intlEndTimeEnd = $this->formatter->formatAsTime($dateEnd);
 
         $output = '<time itemprop="startDate" datetime="' . $dateFrom->format(\DateTime::ATOM) . '">';
-        $output .= '<span class="cf-from cf-meta">' . ucfirst($this->trans->getTranslations()->t('from')) . '</span>';
+        $output .= '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-weekday cf-meta">' . $intlWeekDayFrom . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $intlDateFrom . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-at cf-meta">' . $this->trans->getTranslations()->t('at') . '</span>';
+        $output .= '<span class="cf-at cf-meta">' . $this->translator->getTranslations()->t('at') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-time">' . $intlStartTimeFrom . '</span>';
         $output .= '</time>';
         $output .= ' ';
-        $output .= '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till') . '</span>';
+        $output .= '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>';
         $output .= ' ';
         $output .= '<time itemprop="endDate" datetime="' . $dateEnd->format(\DateTime::ATOM) . '">';
         $output .= '<span class="cf-weekday cf-meta">' . $intlWeekDayEnd . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $intlDateEnd . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-at cf-meta">' . $this->trans->getTranslations()->t('at') . '</span>';
+        $output .= '<span class="cf-at cf-meta">' . $this->translator->getTranslations()->t('at') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-time">' . $intlEndTimeEnd . '</span>';
         $output .= '</time>';

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -23,9 +23,7 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -61,7 +61,7 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
                 . ' '
                 . '<span class="cf-date">' . $intlDateFrom . '</span>'
                 . ' '
-                . '<span class="cf-from cf-meta">' . $this->translator->getTranslations()->t('at') . '</span>'
+                . '<span class="cf-from cf-meta">' . $this->translator->translate('at') . '</span>'
                 . ' '
                 . '<span class="cf-time">' . $intlStartTimeFrom . '</span>'
                 . '</time>';
@@ -72,12 +72,12 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
             . ' '
             . '<span class="cf-date">' . $intlDateFrom . '</span>'
             . ' '
-            . '<span class="cf-from cf-meta">' . $this->translator->getTranslations()->t('from') . '</span>'
+            . '<span class="cf-from cf-meta">' . $this->translator->translate('from') . '</span>'
             . ' '
             . '<span class="cf-time">' . $intlStartTimeFrom . '</span>'
             . '</time>'
             . ' '
-            . '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>'
+            . '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>'
             . ' '
             . '<time itemprop="endDate" datetime="' . $dateEnd->format(\DateTime::ATOM) . '">'
             . '<span class="cf-time">' . $intlEndTimeEnd . '</span>'
@@ -95,25 +95,25 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
         $intlEndTimeEnd = $this->formatter->formatAsTime($dateEnd);
 
         $output = '<time itemprop="startDate" datetime="' . $dateFrom->format(\DateTime::ATOM) . '">';
-        $output .= '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span>';
+        $output .= '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-weekday cf-meta">' . $intlWeekDayFrom . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $intlDateFrom . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-at cf-meta">' . $this->translator->getTranslations()->t('at') . '</span>';
+        $output .= '<span class="cf-at cf-meta">' . $this->translator->translate('at') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-time">' . $intlStartTimeFrom . '</span>';
         $output .= '</time>';
         $output .= ' ';
-        $output .= '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>';
+        $output .= '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>';
         $output .= ' ';
         $output .= '<time itemprop="endDate" datetime="' . $dateEnd->format(\DateTime::ATOM) . '">';
         $output .= '<span class="cf-weekday cf-meta">' . $intlWeekDayEnd . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $intlDateEnd . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-at cf-meta">' . $this->translator->getTranslations()->t('at') . '</span>';
+        $output .= '<span class="cf-at cf-meta">' . $this->translator->translate('at') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-time">' . $intlEndTimeEnd . '</span>';
         $output .= '</time>';

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -19,12 +19,12 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -48,7 +48,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
         $formattedStartTime = $this->formatter->formatAsTime($startDate);
         $formattedEndTime = $this->formatter->formatAsTime($endDate);
 
-        $summaryBuilder = PlainTextSummaryBuilder::start($this->trans)
+        $summaryBuilder = PlainTextSummaryBuilder::start($this->translator)
             ->append($formattedStartDayOfWeek)
             ->append($formattedStartDate);
 
@@ -78,7 +78,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
         $formattedEndDayOfWeek = $this->formatter->formatAsDayOfWeek($endDate);
         $formattedEndTime = $this->formatter->formatAsTime($endDate);
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->from($formattedStartDayOfWeek, $formattedStartDate)
             ->at($formattedStartTime)
             ->till($formattedEndDayOfWeek, $formattedEndDate)

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -24,9 +24,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -23,9 +23,7 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -60,13 +60,13 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
         $intlDateEnd = $this->formatter->formatAsFullDate($dateEnd);
         $intlDateDayEnd = $this->formatter->formatAsDayOfWeek($dateEnd);
 
-        $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span>';
+        $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-weekday cf-meta">' . $intlDateDayFrom . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $intlDateFrom . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>';
+        $output .= '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-weekday cf-meta">' . $intlDateDayEnd . '</span>';
         $output .= ' ';

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -18,12 +18,12 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -60,13 +60,13 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
         $intlDateEnd = $this->formatter->formatAsFullDate($dateEnd);
         $intlDateDayEnd = $this->formatter->formatAsDayOfWeek($dateEnd);
 
-        $output = '<span class="cf-from cf-meta">' . ucfirst($this->trans->getTranslations()->t('from')) . '</span>';
+        $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-weekday cf-meta">' . $intlDateDayFrom . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $intlDateFrom . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till') . '</span>';
+        $output .= '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-weekday cf-meta">' . $intlDateDayEnd . '</span>';
         $output .= ' ';

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -19,12 +19,12 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -56,7 +56,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
         $formattedEndDate = $this->formatter->formatAsFullDate($endDate);
         $formattedEndDayOfWeek = $this->formatter->formatAsDayOfWeek($endDate);
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->from($formattedStartDayOfWeek, $formattedStartDate)
             ->till($formattedEndDayOfWeek, $formattedEndDate)
             ->toString();

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -24,9 +24,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -18,12 +18,12 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -58,13 +58,13 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
         $dateEndDay = $this->formatter->formatAsDayNumber($dateEnd);
         $dateEndMonth = $this->formatter->formatAsAbbreviatedMonthName($dateEnd);
 
-        $output = '<span class="cf-from cf-meta">' . ucfirst($this->trans->getTranslations()->t('from')) . '</span>';
+        $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $dateFromDay . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-month">' . $dateFromMonth . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-to cf-meta">' . $this->trans->getTranslations()->t('till') . '</span>';
+        $output .= '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $dateEndDay . '</span>';
         $output .= ' ';

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -58,13 +58,13 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
         $dateEndDay = $this->formatter->formatAsDayNumber($dateEnd);
         $dateEndMonth = $this->formatter->formatAsAbbreviatedMonthName($dateEnd);
 
-        $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->getTranslations()->t('from')) . '</span>';
+        $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $dateFromDay . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-month">' . $dateFromMonth . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-to cf-meta">' . $this->translator->getTranslations()->t('till') . '</span>';
+        $output .= '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $dateEndDay . '</span>';
         $output .= ' ';

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -23,9 +23,7 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -19,12 +19,12 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
     /**
      * @var Translator
      */
-    private $trans;
+    private $translator;
 
-    public function __construct(string $langCode)
+    public function __construct(Translator $translator)
     {
-        $this->formatter = new DateFormatter($langCode);
-        $this->trans = new Translator($langCode);
+        $this->formatter = new DateFormatter($translator->getLocale());
+        $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
@@ -56,7 +56,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
         $endDayNumber = $this->formatter->formatAsDayNumber($endDate);
         $endMonthName = $this->formatter->formatAsAbbreviatedMonthName($endDate);
 
-        return PlainTextSummaryBuilder::start($this->trans)
+        return PlainTextSummaryBuilder::start($this->translator)
             ->from($startDayNumber, $startMonthName)
             ->till($endDayNumber, $endMonthName)
             ->toString();

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -24,9 +24,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
     public function __construct(string $langCode)
     {
         $this->formatter = new DateFormatter($langCode);
-
-        $this->trans = new Translator();
-        $this->trans->setLanguage($langCode);
+        $this->trans = new Translator($langCode);
     }
 
     public function format(Offer $offer): string

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -12,9 +12,13 @@ final class Translator
      */
     private $translator;
 
-    public function __construct()
-    {
+    /**
+     * @var string
+     */
+    private $locale;
 
+    public function __construct(string $locale)
+    {
         $messages = [
             'en' => [
                 'from' => 'from',
@@ -73,11 +77,9 @@ final class Translator
                 "available" => ['en', 'nl', 'fr', 'de'],
             ]
         );
-    }
 
-    public function setLanguage($langCode): void
-    {
-        $this->translator->setLanguage(substr($langCode, 0, 2));
+        $this->locale = $locale;
+        $this->translator->setLanguage(substr($locale, 0, 2));
     }
 
     public function getTranslations(): Translate

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -79,11 +79,21 @@ final class Translator
         );
 
         $this->locale = $locale;
-        $this->translator->setLanguage(substr($locale, 0, 2));
+        $this->translator->setLanguage($this->getLanguageCode());
     }
 
     public function getTranslations(): Translate
     {
         return $this->translator;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getLanguageCode(): string
+    {
+        return substr($this->locale, 0, 2);
     }
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -82,6 +82,11 @@ final class Translator
         $this->translator->setLanguage($this->getLanguageCode());
     }
 
+    public function translate(string $key): string
+    {
+        return $this->getTranslations()->t($key);
+    }
+
     public function getTranslations(): Translate
     {
         return $this->translator;

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -84,12 +84,7 @@ final class Translator
 
     public function translate(string $key): string
     {
-        return $this->getTranslations()->t($key);
-    }
-
-    public function getTranslations(): Translate
-    {
-        return $this->translator;
+        return $this->translator->t($key);
     }
 
     /**

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -87,11 +87,17 @@ final class Translator
         return $this->translator;
     }
 
+    /**
+     * e.g. 'nl_BE'
+     */
     public function getLocale(): string
     {
         return $this->locale;
     }
 
+    /**
+     * e.g. 'nl'
+     */
     public function getLanguageCode(): string
     {
         return substr($this->locale, 0, 2);

--- a/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
@@ -13,14 +13,16 @@ use PHPUnit\Framework\TestCase;
 class NonAvailablePlaceHTMLFormatterTest extends TestCase
 {
     /**
-     * @var Translator
+     * @var NonAvailablePlaceHTMLFormatter
      */
-    private $translator;
+    private $formatter;
 
     protected function setUp(): void
     {
-        $this->translator = new Translator();
-        $this->translator->setLanguage('nl');
+        $translator = new Translator();
+        $translator->setLanguage('nl');
+
+        $this->formatter = new NonAvailablePlaceHTMLFormatter($translator);
     }
 
     public function testWillInterceptUnavailablePlace(): void
@@ -28,8 +30,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $place,
             function () {
                 return 'foo';
@@ -44,8 +45,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $place,
             function () {
                 return 'foo';
@@ -60,8 +60,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('Available'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $place,
             function () {
                 return 'foo';
@@ -76,8 +75,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $event,
             function () {
                 return 'foo';
@@ -92,8 +90,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $event,
             function () {
                 return 'foo';
@@ -108,8 +105,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $event,
             function () {
                 return 'foo';

--- a/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Middleware;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use CultuurNet\SearchV3\ValueObjects\Status;
@@ -11,12 +12,23 @@ use PHPUnit\Framework\TestCase;
 
 class NonAvailablePlaceHTMLFormatterTest extends TestCase
 {
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    protected function setUp(): void
+    {
+        $this->translator = new Translator();
+        $this->translator->setLanguage('nl');
+    }
+
     public function testWillInterceptUnavailablePlace(): void
     {
         $place = new Place();
         $place->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter('nl');
+        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
         $result = $formatter->format(
             $place,
             function () {
@@ -32,7 +44,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter('nl');
+        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
         $result = $formatter->format(
             $place,
             function () {
@@ -48,7 +60,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('Available'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter('nl');
+        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
         $result = $formatter->format(
             $place,
             function () {
@@ -64,7 +76,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter('nl');
+        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
         $result = $formatter->format(
             $event,
             function () {
@@ -80,7 +92,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter('nl');
+        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
         $result = $formatter->format(
             $event,
             function () {
@@ -96,7 +108,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlaceHTMLFormatter('nl');
+        $formatter = new NonAvailablePlaceHTMLFormatter($this->translator);
         $result = $formatter->format(
             $event,
             function () {

--- a/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
@@ -19,9 +19,7 @@ class NonAvailablePlaceHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $translator = new Translator();
-        $translator->setLanguage('nl');
-
+        $translator = new Translator('nl_BE');
         $this->formatter = new NonAvailablePlaceHTMLFormatter($translator);
     }
 

--- a/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
@@ -19,9 +19,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $translator = new Translator();
-        $translator->setLanguage('nl');
-
+        $translator = new Translator('nl_BE');
         $this->formatter = new NonAvailablePlacePlainTextFormatter($translator);
     }
 

--- a/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
@@ -13,14 +13,16 @@ use PHPUnit\Framework\TestCase;
 class NonAvailablePlacePlainTextFormatterTest extends TestCase
 {
     /**
-     * @var Translator
+     * @var NonAvailablePlacePlainTextFormatter
      */
-    private $translator;
+    private $formatter;
 
     protected function setUp(): void
     {
-        $this->translator = new Translator();
-        $this->translator->setLanguage('nl');
+        $translator = new Translator();
+        $translator->setLanguage('nl');
+
+        $this->formatter = new NonAvailablePlacePlainTextFormatter($translator);
     }
 
     public function testWillInterceptUnavailablePlace(): void
@@ -28,8 +30,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $place,
             function () {
                 return 'foo';
@@ -44,8 +45,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $place,
             function () {
                 return 'foo';
@@ -60,8 +60,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('Available'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $place,
             function () {
                 return 'foo';
@@ -76,8 +75,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $event,
             function () {
                 return 'foo';
@@ -92,8 +90,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $event,
             function () {
                 return 'foo';
@@ -108,8 +105,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
-        $result = $formatter->format(
+        $result = $this->formatter->format(
             $event,
             function () {
                 return 'foo';

--- a/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Middleware;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use CultuurNet\SearchV3\ValueObjects\Status;
@@ -11,12 +12,23 @@ use PHPUnit\Framework\TestCase;
 
 class NonAvailablePlacePlainTextFormatterTest extends TestCase
 {
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    protected function setUp(): void
+    {
+        $this->translator = new Translator();
+        $this->translator->setLanguage('nl');
+    }
+
     public function testWillInterceptUnavailablePlace(): void
     {
         $place = new Place();
         $place->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter('nl');
+        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
         $result = $formatter->format(
             $place,
             function () {
@@ -32,7 +44,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter('nl');
+        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
         $result = $formatter->format(
             $place,
             function () {
@@ -48,7 +60,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $place = new Place();
         $place->setStatus(new Status('Available'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter('nl');
+        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
         $result = $formatter->format(
             $place,
             function () {
@@ -64,7 +76,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter('nl');
+        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
         $result = $formatter->format(
             $event,
             function () {
@@ -80,7 +92,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('TemporarilyUnavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter('nl');
+        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
         $result = $formatter->format(
             $event,
             function () {
@@ -96,7 +108,7 @@ class NonAvailablePlacePlainTextFormatterTest extends TestCase
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
 
-        $formatter = new NonAvailablePlacePlainTextFormatter('nl');
+        $formatter = new NonAvailablePlacePlainTextFormatter($this->translator);
         $result = $formatter->format(
             $event,
             function () {

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class ExtraSmallMultipleHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new ExtraSmallMultipleHTMLFormatter('nl_NL');
+        $this->formatter = new ExtraSmallMultipleHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new ExtraSmallMultiplePlainTextFormatter('nl_NL');
+        $this->formatter = new ExtraSmallMultiplePlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/LargeMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/LargeMultipleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class LargeMultipleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         date_default_timezone_set('Europe/Brussels');
-        $this->formatter = new LargeMultipleHTMLFormatter('nl_NL', false);
+        $this->formatter = new LargeMultipleHTMLFormatter(new Translator('nl_NL'), false);
     }
 
     public function testFormatHTMLMultipleDateLargeOneDay(): void

--- a/tests/Multiple/LargeMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/LargeMultiplePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class LargeMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         date_default_timezone_set('Europe/Brussels');
-        $this->formatter = new LargeMultiplePlainTextFormatter('nl_NL', false);
+        $this->formatter = new LargeMultiplePlainTextFormatter(new Translator('nl_NL'), false);
     }
 
     public function testFormatPlainTextMultipleDateLargeOneDay(): void

--- a/tests/Multiple/MediumMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/MediumMultipleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class MediumMultipleHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumMultipleHTMLFormatter('nl_NL', false);
+        $this->formatter = new MediumMultipleHTMLFormatter(new Translator('nl_NL'), false);
     }
 
     public function testFormatHTMLMultipleDateMediumOneDay(): void

--- a/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class MediumMultiplePlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumMultiplePlainTextFormatter('nl_NL', false);
+        $this->formatter = new MediumMultiplePlainTextFormatter(new Translator('nl_NL'), false);
     }
 
     public function testFormatPlainTextMultipleDateMediumOneDay(): void

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class SmallMultipleHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new SmallMultipleHTMLFormatter('nl_NL');
+        $this->formatter = new SmallMultipleHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class SmallMultiplePlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new SmallMultiplePlainTextFormatter('nl_NL');
+        $this->formatter = new SmallMultiplePlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new ExtraSmallPeriodicHTMLFormatter('nl_NL');
+        $this->formatter = new ExtraSmallPeriodicHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new ExtraSmallPeriodicPlainTextFormatter('nl_NL');
+        $this->formatter = new ExtraSmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/LargePeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/LargePeriodicHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class LargePeriodicHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new LargePeriodicHTMLFormatter('nl_NL');
+        $this->formatter = new LargePeriodicHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithSingleTimeBlocks(): void

--- a/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new LargePeriodicPlainTextFormatter('nl_NL');
+        $this->formatter = new LargePeriodicPlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithSingleTimeBlocks(): void

--- a/tests/Periodic/MediumPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class MediumPeriodicHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumPeriodicHTMLFormatter('nl_NL');
+        $this->formatter = new MediumPeriodicHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class MediumPeriodicPlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumPeriodicPlainTextFormatter('nl_NL');
+        $this->formatter = new MediumPeriodicPlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class SmallPeriodicHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new SmallPeriodicHTMLFormatter('nl_NL');
+        $this->formatter = new SmallPeriodicHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class SmallPeriodicPlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new SmallPeriodicPlainTextFormatter('nl_NL');
+        $this->formatter = new SmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Permanent/LargePermanentHTMLFormatterTest.php
+++ b/tests/Permanent/LargePermanentHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class LargePermanentHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new LargePermanentHTMLFormatter('nl_NL');
+        $this->formatter = new LargePermanentHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatASimplePermanent(): void

--- a/tests/Permanent/LargePermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/LargePermanentPlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class LargePermanentPlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new LargePermanentPlainTextFormatter('nl_NL');
+        $this->formatter = new LargePermanentPlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatASimplePermanent(): void

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class MediumPermanentHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumPermanentHTMLFormatter('nl_NL');
+        $this->formatter = new MediumPermanentHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatASimplePermanent(): void

--- a/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class MediumPermanentPlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumPermanentPlainTextFormatter('nl_NL');
+        $this->formatter = new MediumPermanentPlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatASimplePermanent(): void

--- a/tests/Single/LargeSingleHTMLFormatterTest.php
+++ b/tests/Single/LargeSingleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class LargeSingleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         date_default_timezone_set('Europe/Brussels');
-        $this->formatter = new LargeSingleHTMLFormatter('nl_NL');
+        $this->formatter = new LargeSingleHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatHTMLSingleDateLargeOneDay(): void

--- a/tests/Single/LargeSinglePlainTextFormatterTest.php
+++ b/tests/Single/LargeSinglePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class LargeSinglePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         date_default_timezone_set('Europe/Brussels');
-        $this->formatter = new LargeSinglePlainTextFormatter('nl_NL');
+        $this->formatter = new LargeSinglePlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatPlainTextSingleDateLargeOneDay(): void

--- a/tests/Single/MediumSingleHTMLFormatterTest.php
+++ b/tests/Single/MediumSingleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class MediumSingleHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumSingleHTMLFormatter('nl_NL');
+        $this->formatter = new MediumSingleHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatHTMLSingleDateMediumOneDay(): void

--- a/tests/Single/MediumSinglePlainTextFormatterTest.php
+++ b/tests/Single/MediumSinglePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new MediumSinglePlainTextFormatter('nl_NL');
+        $this->formatter = new MediumSinglePlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatHTMLSingleDateMediumOneDay(): void

--- a/tests/Single/SmallSingleHTMLFormatterTest.php
+++ b/tests/Single/SmallSingleHTMLFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class SmallSingleHTMLFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new SmallSingleHTMLFormatter('nl_NL');
+        $this->formatter = new SmallSingleHTMLFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatHTMLSingleDateXsOneDay(): void

--- a/tests/Single/SmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/SmallSinglePlainTextFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class SmallSinglePlainTextFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formatter = new SmallSinglePlainTextFormatter('nl_NL');
+        $this->formatter = new SmallSinglePlainTextFormatter(new Translator('nl_NL'));
     }
 
     public function testFormatPlainTextSingleDateXsOneDay(): void


### PR DESCRIPTION
### Changed
- `Translator` is now injected into formatters instead of created on the fly

### Removed
- [BREAKING] `Translator` no longer has a `setLanguage()` method. A new `Translator` instance should be created if we want to translate to a different language.