### PR TITLE
Unavailable permanent events

### DIFF
--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -39,20 +39,12 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
-        if ($offer->getStatus()->getType() === 'Unavailable') {
-            return $this->formatSummary(
-                '<p class="cf-openinghours">'
-                . $this->translator->translate('cancelled')
-                . '</p>'
-            );
-        }
+        if ($offer->getStatus()->getType() !== 'Available') {
+            $statusText = $offer->getStatus()->getType() === 'Unavailable' ?
+                $this->translator->translate('cancelled') :
+                $this->translator->translate('postponed');
 
-        if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
-            return $this->formatSummary(
-                '<p class="cf-openinghours">'
-                . $this->translator->translate('postponed')
-                . '</p>'
-            );
+            return '<p class="cf-openinghours">' . $statusText . '</p>';
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
+use CultuurNet\CalendarSummaryV3\TranslatedStatusReasonFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
@@ -44,7 +45,10 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
                 $this->translator->translate('cancelled') :
                 $this->translator->translate('postponed');
 
-            return '<p class="cf-openinghours">' . $statusText . '</p>';
+            $reasonFormatter = new TranslatedStatusReasonFormatter($this->translator);
+            $titleAttribute = $reasonFormatter->formatAsTitleAttribute($offer->getStatus());
+
+            return '<p ' . $titleAttribute . 'class="cf-openinghours">' . $statusText . '</p>';
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -39,6 +39,22 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
+        if ($offer->getStatus()->getType() === 'Unavailable') {
+            return $this->formatSummary(
+                '<p class="cf-openinghours">'
+                . $this->translator->translate('cancelled')
+                . '</p>'
+            );
+        }
+
+        if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
+            return $this->formatSummary(
+                '<p class="cf-openinghours">'
+                . $this->translator->translate('postponed')
+                . '</p>'
+            );
+        }
+
         if ($offer->getOpeningHours()) {
             return $this->formatSummary($this->generateWeekScheme($offer->getOpeningHours()));
         }

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -30,6 +30,14 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
 
     public function format(Offer $offer): string
     {
+        if ($offer->getStatus()->getType() === 'Unavailable') {
+            return $this->translator->translate('cancelled');
+        }
+
+        if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
+            return $this->translator->translate('postponed');
+        }
+
         if ($offer->getOpeningHours()) {
             return $this->generateWeekScheme($offer->getOpeningHours());
         }

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -6,6 +6,7 @@ use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use DateTimeImmutable;
 
 final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
@@ -28,12 +29,12 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
-        if ($offer->getStatus()->getType() === 'Unavailable') {
-            return '<p class="cf-openinghours">' . $this->translator->translate('cancelled') . '</p>';
-        }
+        if ($offer->getStatus()->getType() !== 'Available') {
+            $statusText = $offer->getStatus()->getType() === 'Unavailable' ?
+                $this->translator->translate('cancelled') :
+                $this->translator->translate('postponed');
 
-        if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
-            return '<p class="cf-openinghours">' . $this->translator->translate('postponed') . '</p>';
+            return '<p class="cf-openinghours">' . $statusText . '</p>';
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
+use CultuurNet\CalendarSummaryV3\TranslatedStatusReasonFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
@@ -34,7 +35,10 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
                 $this->translator->translate('cancelled') :
                 $this->translator->translate('postponed');
 
-            return '<p class="cf-openinghours">' . $statusText . '</p>';
+            $reasonFormatter = new TranslatedStatusReasonFormatter($this->translator);
+            $titleAttribute = $reasonFormatter->formatAsTitleAttribute($offer->getStatus());
+
+            return '<p ' . $titleAttribute . 'class="cf-openinghours">' . $statusText . '</p>';
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -28,6 +28,14 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
+        if ($offer->getStatus()->getType() === 'Unavailable') {
+            return '<p class="cf-openinghours">' . $this->translator->translate('cancelled') . '</p>';
+        }
+
+        if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
+            return '<p class="cf-openinghours">' . $this->translator->translate('postponed') . '</p>';
+        }
+
         if ($offer->getOpeningHours()) {
             return $this->generateWeekScheme($offer->getOpeningHours());
         }

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -29,6 +29,14 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
 
     public function format(Offer $offer): string
     {
+        if ($offer->getStatus()->getType() === 'Unavailable') {
+            return $this->translator->translate('cancelled');
+        }
+
+        if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
+            return $this->translator->translate('postponed');
+        }
+
         if ($offer->getOpeningHours()) {
             return $this->generateWeekScheme($offer->getOpeningHours());
         }

--- a/src/TranslatedStatusReasonFormatter.php
+++ b/src/TranslatedStatusReasonFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3;
+
+use CultuurNet\SearchV3\ValueObjects\Status;
+
+class TranslatedStatusReasonFormatter
+{
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function formatAsTitleAttribute(Status $status): string
+    {
+        $reason = $reason = $status->getReason();
+
+        if (!$reason) {
+            return '';
+        }
+
+        $translatedReason = $reason->getValueForLanguage($this->translator->getLanguageCode());
+
+        if (empty($translatedReason)) {
+            return '';
+        }
+
+        return 'title="' . $translatedReason . '" ';
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -31,6 +31,8 @@ final class Translator
                 'and' => 'and',
                 'permanently_closed' => 'Permanently closed',
                 'temporarily_closed' => 'Temporarily closed',
+                'cancelled' => 'Cancelled',
+                'postponed' => 'Postponed',
             ],
             'nl' => [
                 'from' => 'van',
@@ -43,6 +45,8 @@ final class Translator
                 'and' => 'en',
                 'permanently_closed' => 'Permanent gesloten',
                 'temporarily_closed' => 'Tijdelijk gesloten',
+                'cancelled' => 'Geannuleerd',
+                'postponed' => 'Uitgesteld',
             ],
             'fr' => [
                 'from' => 'du',
@@ -55,6 +59,8 @@ final class Translator
                 'and' => 'et',
                 'permanently_closed' => 'Fermé définitivement',
                 'temporarily_closed' => 'Fermé temporairement',
+                'cancelled' => 'Annulé',
+                'postponed' => 'Reporté',
             ],
             'de' => [
                 'from' => 'von',
@@ -67,7 +73,9 @@ final class Translator
                 'and' => 'und',
                 'permanently_closed' => 'Dauerhaft geschlossen',
                 'temporarily_closed' => 'Vorübergehend geschlossen',
-            ]
+                'cancelled' => 'Abgesagt',
+                'postponed' => 'Verschoben',
+            ],
         ];
 
         $this->translator = new Translate(

--- a/tests/Permanent/LargePermanentHTMLFormatterTest.php
+++ b/tests/Permanent/LargePermanentHTMLFormatterTest.php
@@ -3,8 +3,10 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\Translator;
+use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,6 +28,8 @@ class LargePermanentHTMLFormatterTest extends TestCase
     public function testFormatASimplePermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
+
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -110,6 +114,7 @@ class LargePermanentHTMLFormatterTest extends TestCase
     public function testFormatAMixedPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday', 'wednesday']);
@@ -213,6 +218,7 @@ class LargePermanentHTMLFormatterTest extends TestCase
     public function testFormatAComplexPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday']);
@@ -304,6 +310,28 @@ class LargePermanentHTMLFormatterTest extends TestCase
             .'<span itemprop="closed" content="closed" class="cf-closed cf-meta">gesloten</span> '
             .'</li> </ul>',
             $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatAnUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Geannuleerd</p>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatATemporarilyUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Uitgesteld</p>',
+            $this->formatter->format($event)
         );
     }
 }

--- a/tests/Permanent/LargePermanentHTMLFormatterTest.php
+++ b/tests/Permanent/LargePermanentHTMLFormatterTest.php
@@ -7,6 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use CultuurNet\SearchV3\ValueObjects\Status;
+use CultuurNet\SearchV3\ValueObjects\TranslatedString;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -331,6 +332,29 @@ class LargePermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-openinghours">Uitgesteld</p>',
+            $this->formatter->format($event)
+        );
+    }
+
+
+    public function testItRendersReasonAsTitleAttribute(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable', new TranslatedString(['nl' => 'Covid-19'])));
+
+        $this->assertEquals(
+            '<p title="Covid-19" class="cf-openinghours">Geannuleerd</p>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testItDoesNotRendersReasonWhenTranslationIsUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable', new TranslatedString(['fr' => 'Sacre bleu'])));
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Geannuleerd</p>',
             $this->formatter->format($event)
         );
     }

--- a/tests/Permanent/LargePermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/LargePermanentPlainTextFormatterTest.php
@@ -3,8 +3,10 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\Translator;
+use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,6 +28,8 @@ class LargePermanentPlainTextFormatterTest extends TestCase
     public function testFormatASimplePermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
+
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -64,6 +68,8 @@ class LargePermanentPlainTextFormatterTest extends TestCase
     public function testFormatAMixedPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
+
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -106,6 +112,7 @@ class LargePermanentPlainTextFormatterTest extends TestCase
     public function testFormatAComplexPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday']);
@@ -146,6 +153,28 @@ class LargePermanentPlainTextFormatterTest extends TestCase
             . 'Za van 10:00 tot 15:00' . PHP_EOL
             . 'Zo gesloten' . PHP_EOL,
             $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatAnUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+
+        $this->assertEquals(
+            'Geannuleerd',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatATemporarilyUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+
+        $this->assertEquals(
+            'Uitgesteld',
+            $this->formatter->format($event)
         );
     }
 }

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -7,6 +7,7 @@ use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use CultuurNet\SearchV3\ValueObjects\Status;
+use CultuurNet\SearchV3\ValueObjects\TranslatedString;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -167,6 +168,28 @@ class MediumPermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-openinghours">Uitgesteld</p>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testItRendersReasonAsTitleAttribute(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable', new TranslatedString(['nl' => 'Covid-19'])));
+
+        $this->assertEquals(
+            '<p title="Covid-19" class="cf-openinghours">Geannuleerd</p>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testItDoesNotRendersReasonWhenTranslationIsUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable', new TranslatedString(['fr' => 'Sacre bleu'])));
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Geannuleerd</p>',
             $this->formatter->format($event)
         );
     }

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -3,8 +3,10 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\Translator;
+use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,6 +28,8 @@ class MediumPermanentHTMLFormatterTest extends TestCase
     public function testFormatASimplePermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
+
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -64,6 +68,7 @@ class MediumPermanentHTMLFormatterTest extends TestCase
     public function testFormatAMixedPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday', 'wednesday']);
@@ -103,6 +108,7 @@ class MediumPermanentHTMLFormatterTest extends TestCase
     public function testFormatAComplexPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday']);
@@ -140,6 +146,28 @@ class MediumPermanentHTMLFormatterTest extends TestCase
             . '<span class="cf-weekday-open">za</span>'
             . '</span></span>',
             $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatAnUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Geannuleerd</p>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatATemporarilyUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Uitgesteld</p>',
+            $this->formatter->format($event)
         );
     }
 }

--- a/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
@@ -3,8 +3,10 @@
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\Translator;
+use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,6 +28,8 @@ class MediumPermanentPlainTextFormatterTest extends TestCase
     public function testFormatASimplePermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
+
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -57,6 +61,7 @@ class MediumPermanentPlainTextFormatterTest extends TestCase
     public function testFormatAMixedPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday', 'wednesday']);
@@ -90,6 +95,7 @@ class MediumPermanentPlainTextFormatterTest extends TestCase
     public function testFormatAComplexPermanent(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
 
         $openingHours1 = new OpeningHours();
         $openingHours1->setDaysOfWeek(['monday','tuesday']);
@@ -122,6 +128,28 @@ class MediumPermanentPlainTextFormatterTest extends TestCase
         $this->assertEquals(
             'Open op ma, di, vr, za',
             $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatAnUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+
+        $this->assertEquals(
+            'Geannuleerd',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatATemporarilyUnavailablePermanent(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+
+        $this->assertEquals(
+            'Uitgesteld',
+            $this->formatter->format($event)
         );
     }
 }


### PR DESCRIPTION
### Changed
- Events with permanent calendar that are unavailable or temporarily unavailable now indicate that status and the potential reason