### PR TITLE
Append status in plain text rendering of single, multiple and periodic calendars

### DIFF
--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -39,6 +39,7 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
         return PlainTextSummaryBuilder::start($this->translator)
             ->from($this->formatter->formatAsShortDate($startDate))
             ->till($this->formatter->formatAsShortDate($endDate))
+            ->appendStatus($event->getStatus())
             ->toString();
     }
 }

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -34,24 +34,22 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
         $startDate->setTime(0, 0, 1);
 
         if (DateComparison::inTheFuture($startDate)) {
-            return $this->formatNotStarted($startDate);
+            return $this->formatNotStarted($startDate)->appendStatus($offer->getStatus())->toString();
         }
 
         $endDate = $offer->getEndDate();
-        return $this->formatStarted($endDate);
+        return $this->formatStarted($endDate)->appendStatus($offer->getStatus())->toString();
     }
 
-    private function formatStarted(DateTimeInterface $endDate): string
+    private function formatStarted(DateTimeInterface $endDate): PlainTextSummaryBuilder
     {
         return PlainTextSummaryBuilder::start($this->translator)
-            ->till($this->formatter->formatAsShortDate($endDate))
-            ->toString();
+            ->till($this->formatter->formatAsShortDate($endDate));
     }
 
-    private function formatNotStarted(DateTimeInterface $startDate): string
+    private function formatNotStarted(DateTimeInterface $startDate): PlainTextSummaryBuilder
     {
         return PlainTextSummaryBuilder::start($this->translator)
-            ->fromPeriod($this->formatter->formatAsShortDate($startDate))
-            ->toString();
+            ->fromPeriod($this->formatter->formatAsShortDate($startDate));
     }
 }

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -7,8 +7,6 @@ use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\PlainTextSummaryBuilder;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
-use \DateTime;
-use \DateTimeInterface;
 
 final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInterface
 {
@@ -34,22 +32,16 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
         $startDate->setTime(0, 0, 1);
 
         if (DateComparison::inTheFuture($startDate)) {
-            return $this->formatNotStarted($startDate)->appendStatus($offer->getStatus())->toString();
+            return PlainTextSummaryBuilder::start($this->translator)
+                ->fromPeriod($this->formatter->formatAsShortDate($startDate))
+                ->appendStatus($offer->getStatus())
+                ->toString();
         }
 
         $endDate = $offer->getEndDate();
-        return $this->formatStarted($endDate)->appendStatus($offer->getStatus())->toString();
-    }
-
-    private function formatStarted(DateTimeInterface $endDate): PlainTextSummaryBuilder
-    {
         return PlainTextSummaryBuilder::start($this->translator)
-            ->till($this->formatter->formatAsShortDate($endDate));
-    }
-
-    private function formatNotStarted(DateTimeInterface $startDate): PlainTextSummaryBuilder
-    {
-        return PlainTextSummaryBuilder::start($this->translator)
-            ->fromPeriod($this->formatter->formatAsShortDate($startDate));
+            ->till($this->formatter->formatAsShortDate($endDate))
+            ->appendStatus($offer->getStatus())
+            ->toString();
     }
 }

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -47,7 +47,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
                 ->append($this->generateWeekScheme($offer->getOpeningHours()));
         }
 
-        return $summary->toString();
+        return $summary->appendStatus($offer->getStatus())->toString();
     }
 
     private function generateDates(DateTime $dateFrom, DateTime $dateTo): string

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -34,13 +34,19 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $formattedEndDate = $this->formatter->formatAsFullDate($endDate);
 
+        $summaryBuilder = PlainTextSummaryBuilder::start($this->translator);
+
         if ($formattedStartDate === $formattedEndDate) {
-            return PlainTextSummaryBuilder::singleLine($formattedStartDayOfWeek, $formattedStartDate);
+            return $summaryBuilder->append($formattedStartDayOfWeek)
+                ->append($formattedStartDate)
+                ->appendStatus($offer->getStatus())
+                ->toString();
         }
 
-        return PlainTextSummaryBuilder::start($this->translator)
+        return $summaryBuilder
             ->from($formattedStartDate)
             ->till($formattedEndDate)
+            ->appendStatus($offer->getStatus())
             ->toString();
     }
 }

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -7,7 +7,6 @@ use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\PlainTextSummaryBuilder;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
-use \DateTime;
 use \DateTimeInterface;
 
 final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterface

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -33,26 +33,25 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         $startDate = $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $startDate->setTime(0, 0, 1);
 
+
         if (DateComparison::inTheFuture($startDate)) {
-            return $this->formatNotStarted($startDate);
+            return $this->formatNotStarted($startDate)->appendStatus($offer->getStatus())->toString();
         }
 
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-        return $this->formatStarted($endDate);
+        return $this->formatStarted($endDate)->appendStatus($offer->getStatus())->toString();
     }
 
-    private function formatStarted(DateTimeInterface $endDate): string
+    private function formatStarted(DateTimeInterface $endDate): PlainTextSummaryBuilder
     {
         return PlainTextSummaryBuilder::start($this->translator)
-            ->till($this->formatDate($endDate))
-            ->toString();
+            ->till($this->formatDate($endDate));
     }
 
-    private function formatNotStarted(DateTimeInterface $startDate): string
+    private function formatNotStarted(DateTimeInterface $startDate): PlainTextSummaryBuilder
     {
         return PlainTextSummaryBuilder::start($this->translator)
-            ->fromPeriod($this->formatDate($startDate))
-            ->toString();
+            ->fromPeriod($this->formatDate($startDate));
     }
 
     private function formatDate(DateTimeInterface $date): string

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -33,25 +33,18 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         $startDate = $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $startDate->setTime(0, 0, 1);
 
-
         if (DateComparison::inTheFuture($startDate)) {
-            return $this->formatNotStarted($startDate)->appendStatus($offer->getStatus())->toString();
+            return PlainTextSummaryBuilder::start($this->translator)
+                ->fromPeriod($this->formatDate($startDate))
+                ->appendStatus($offer->getStatus())
+                ->toString();
         }
 
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-        return $this->formatStarted($endDate)->appendStatus($offer->getStatus())->toString();
-    }
-
-    private function formatStarted(DateTimeInterface $endDate): PlainTextSummaryBuilder
-    {
         return PlainTextSummaryBuilder::start($this->translator)
-            ->till($this->formatDate($endDate));
-    }
-
-    private function formatNotStarted(DateTimeInterface $startDate): PlainTextSummaryBuilder
-    {
-        return PlainTextSummaryBuilder::start($this->translator)
-            ->fromPeriod($this->formatDate($startDate));
+            ->till($this->formatDate($endDate))
+            ->appendStatus($offer->getStatus())
+            ->toString();
     }
 
     private function formatDate(DateTimeInterface $date): string

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -48,7 +48,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
             $reasonFormatter = new TranslatedStatusReasonFormatter($this->translator);
             $titleAttribute = $reasonFormatter->formatAsTitleAttribute($offer->getStatus());
 
-            return '<p ' . $titleAttribute . 'class="cf-openinghours">' . $statusText . '</p>';
+            return '<p ' . $titleAttribute . 'class="cf-openinghours">' . ucfirst($statusText) . '</p>';
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -31,11 +31,11 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
     public function format(Offer $offer): string
     {
         if ($offer->getStatus()->getType() === 'Unavailable') {
-            return $this->translator->translate('cancelled');
+            return ucfirst($this->translator->translate('cancelled'));
         }
 
         if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
-            return $this->translator->translate('postponed');
+            return ucfirst($this->translator->translate('postponed'));
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -38,7 +38,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
             $reasonFormatter = new TranslatedStatusReasonFormatter($this->translator);
             $titleAttribute = $reasonFormatter->formatAsTitleAttribute($offer->getStatus());
 
-            return '<p ' . $titleAttribute . 'class="cf-openinghours">' . $statusText . '</p>';
+            return '<p ' . $titleAttribute . 'class="cf-openinghours">' . ucfirst($statusText) . '</p>';
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -30,11 +30,11 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
     public function format(Offer $offer): string
     {
         if ($offer->getStatus()->getType() === 'Unavailable') {
-            return $this->translator->translate('cancelled');
+            return ucfirst($this->translator->translate('cancelled'));
         }
 
         if ($offer->getStatus()->getType() === 'TemporarilyUnavailable') {
-            return $this->translator->translate('postponed');
+            return ucfirst($this->translator->translate('postponed'));
         }
 
         if ($offer->getOpeningHours()) {

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3;
 
+use CultuurNet\SearchV3\ValueObjects\Status;
+
 final class PlainTextSummaryBuilder
 {
     /**
@@ -150,5 +152,21 @@ final class PlainTextSummaryBuilder
     {
         $formatted = implode(' ', $line);
         return $lowercaseFirstCharacter ? lcfirst($formatted) : ucfirst($formatted);
+    }
+
+    public function appendStatus(Status $status): self
+    {
+        $c = clone $this;
+
+        switch ($status->getType()) {
+            case 'Unavailable':
+                $c->workingLine[] = '(' . $this->translator->translate('cancelled') . ')';
+                return $c;
+            case 'TemporarilyUnavailable':
+                $c->workingLine[] = '(' . $this->translator->translate('postponed') . ')';
+                return $c;
+            default:
+                return $c;
+        }
     }
 }

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -38,7 +38,10 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($startDate, $endDate);
         }
 
-        return $output;
+        return PlainTextSummaryBuilder::start($this->translator)
+            ->append($output)
+            ->appendStatus($offer->getStatus())
+            ->toString();
     }
 
     private function formatSameDay(DateTimeInterface $startDate, DateTimeInterface $endDate): string

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -38,7 +38,10 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($startDate, $endDate);
         }
 
-        return $output;
+        return PlainTextSummaryBuilder::start($this->translator)
+            ->append($output)
+            ->appendStatus($offer->getStatus())
+            ->toString();
     }
 
     private function formatSameDay(DateTimeInterface $date): string

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -41,7 +41,8 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendStatus($offer->getStatus());
+            ->appendStatus($offer->getStatus())
+            ->toString();
     }
 
     private function formatSameDay(DateTimeInterface $date): string

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -39,7 +39,9 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($startDate, $endDate);
         }
 
-        return $output . $this->appendOptionalStatus($offer->getStatus());
+        return PlainTextSummaryBuilder::start($this->translator)
+            ->append($output)
+            ->appendStatus($offer->getStatus());
     }
 
     private function formatSameDay(DateTimeInterface $date): string
@@ -61,17 +63,5 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
             ->from($startDayNumber, $startMonthName)
             ->till($endDayNumber, $endMonthName)
             ->toString();
-    }
-
-    private function appendOptionalStatus(Status $status): string
-    {
-        switch ($status->getType()) {
-            case 'Unavailable':
-                return ' (' . $this->translator->translate('cancelled') . ')';
-            case 'TemporarilyUnavailable':
-                return ' (' . $this->translator->translate('postponed') . ')';
-            default:
-                return '';
-        }
     }
 }

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -7,6 +7,7 @@ use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\PlainTextSummaryBuilder;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Offer;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use DateTimeInterface;
 
 final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
@@ -38,7 +39,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($startDate, $endDate);
         }
 
-        return $output;
+        return $output . $this->appendOptionalStatus($offer->getStatus());
     }
 
     private function formatSameDay(DateTimeInterface $date): string
@@ -60,5 +61,17 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
             ->from($startDayNumber, $startMonthName)
             ->till($endDayNumber, $endMonthName)
             ->toString();
+    }
+
+    private function appendOptionalStatus(Status $status): string
+    {
+        switch ($status->getType()) {
+            case 'Unavailable':
+                return ' (' . $this->translator->translate('cancelled') . ')';
+            case 'TemporarilyUnavailable':
+                return ' (' . $this->translator->translate('postponed') . ')';
+            default:
+                return '';
+        }
     }
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -31,8 +31,8 @@ final class Translator
                 'and' => 'and',
                 'permanently_closed' => 'Permanently closed',
                 'temporarily_closed' => 'Temporarily closed',
-                'cancelled' => 'Cancelled',
-                'postponed' => 'Postponed',
+                'cancelled' => 'cancelled',
+                'postponed' => 'postponed',
             ],
             'nl' => [
                 'from' => 'van',
@@ -45,8 +45,8 @@ final class Translator
                 'and' => 'en',
                 'permanently_closed' => 'Permanent gesloten',
                 'temporarily_closed' => 'Tijdelijk gesloten',
-                'cancelled' => 'Geannuleerd',
-                'postponed' => 'Uitgesteld',
+                'cancelled' => 'geannuleerd',
+                'postponed' => 'uitgesteld',
             ],
             'fr' => [
                 'from' => 'du',
@@ -59,8 +59,8 @@ final class Translator
                 'and' => 'et',
                 'permanently_closed' => 'Fermé définitivement',
                 'temporarily_closed' => 'Fermé temporairement',
-                'cancelled' => 'Annulé',
-                'postponed' => 'Reporté',
+                'cancelled' => 'annulé',
+                'postponed' => 'reporté',
             ],
             'de' => [
                 'from' => 'von',
@@ -73,8 +73,8 @@ final class Translator
                 'and' => 'und',
                 'permanently_closed' => 'Dauerhaft geschlossen',
                 'temporarily_closed' => 'Vorübergehend geschlossen',
-                'cancelled' => 'Abgesagt',
-                'postponed' => 'Verschoben',
+                'cancelled' => 'abgesagt',
+                'postponed' => 'verschoben',
             ],
         ];
 

--- a/tests/CalendarPlainTextFormatterTest.php
+++ b/tests/CalendarPlainTextFormatterTest.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\CalendarSummaryV3;
 
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class CalendarPlainTextFormatterTest extends TestCase
@@ -20,6 +21,7 @@ class CalendarPlainTextFormatterTest extends TestCase
     public function testGeneralFormatMethod(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setCalendarType(Event::CALENDAR_TYPE_SINGLE);
         $offer->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $offer->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
@@ -30,6 +32,7 @@ class CalendarPlainTextFormatterTest extends TestCase
     public function testGeneralFormatMethodAndCatchException(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setCalendarType(Event::CALENDAR_TYPE_SINGLE);
         $offer->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $offer->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
@@ -21,6 +22,7 @@ class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatMultipleWithoutLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-11-2025'));
         $offer->setEndDate(new \DateTime('30-11-2030'));
 
@@ -33,6 +35,7 @@ class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatMultipleWithLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-03-2025'));
         $offer->setEndDate(new \DateTime('08-03-2030'));
 
@@ -42,10 +45,23 @@ class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-11-2025'));
+        $offer->setEndDate(new \DateTime('30-11-2030'));
+
+        $this->assertEquals(
+            'Van 25/11/25 tot 30/11/30 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
 
     public function testFormatMultipleDayWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-03-2025'));
         $offer->setEndDate(new \DateTime('30-03-2030'));
 
@@ -58,6 +74,7 @@ class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatMultipleMonthWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2030'));
 
@@ -70,11 +87,25 @@ class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithSameBeginAndEndDate(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('08-03-2025'));
         $offer->setEndDate(new \DateTime('08-03-2025'));
 
         $this->assertEquals(
             '8/3/25',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleMonthWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('04-10-2025'));
+        $offer->setEndDate(new \DateTime('08-10-2030'));
+
+        $this->assertEquals(
+            'Van 4/10/25 tot 8/10/30 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Multiple/LargeMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/LargeMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class LargeMultiplePlainTextFormatterTest extends TestCase
@@ -23,9 +24,11 @@ class LargeMultiplePlainTextFormatterTest extends TestCase
     {
         $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEvents.json'), true);
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $newEvents = array();
         foreach ($subEvents as $subEvent) {
             $e = new Event();
+            $e->setStatus(new Status('Available'));
             $e->setStartDate(new \DateTime($subEvent['startDate']));
             $e->setEndDate(new \DateTime($subEvent['endDate']));
             $newEvents[] = $e;
@@ -50,13 +53,48 @@ class LargeMultiplePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPlainTextMultipleDateLargeOneDayWithUnavailableStatus(): void
+    {
+        $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEvents.json'), true);
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $newEvents = array();
+        foreach ($subEvents as $subEvent) {
+            $e = new Event();
+            $e->setStatus(new Status('Unavailable'));
+            $e->setStartDate(new \DateTime($subEvent['startDate']));
+            $e->setEndDate(new \DateTime($subEvent['endDate']));
+            $newEvents[] = $e;
+        }
+        $event->setSubEvents($newEvents);
+
+        $expectedOutput = 'Donderdag 9 november 2017';
+        $expectedOutput .= ' van 20:00 tot 22:00 (geannuleerd)' . PHP_EOL;
+
+        $expectedOutput .= 'Donderdag 16 november 2017';
+        $expectedOutput .= ' van 20:00 tot 22:00 (geannuleerd)' . PHP_EOL;
+
+        $expectedOutput .= 'Donderdag 23 november 2017';
+        $expectedOutput .= ' van 20:00 tot 22:00 (geannuleerd)' . PHP_EOL;
+
+        $expectedOutput .= 'Donderdag 30 november 2017';
+        $expectedOutput .= ' van 20:00 tot 22:00 (geannuleerd)';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatPlainTextMultipleDateLargeMoreDays(): void
     {
         $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEventsMoreDays.json'), true);
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $newEvents = array();
         foreach ($subEvents as $subEvent) {
             $e = new Event();
+            $e->setStatus(new Status('Available'));
             $e->setStartDate(new \DateTime($subEvent['startDate']));
             $e->setEndDate(new \DateTime($subEvent['endDate']));
             $newEvents[] = $e;

--- a/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
@@ -96,4 +96,33 @@ class MediumMultiplePlainTextFormatterTest extends TestCase
             $this->formatter->format($event)
         );
     }
+
+    public function testFormatPlainTextMultipleDateMediumOneDayWithUnavailableStatusForSingleSubEvent(): void
+    {
+        $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEvents.json'), true);
+        $event = new Event();
+        $event->setStatus(new Status('Available'));
+        $newEvents = array();
+        foreach ($subEvents as $subEvent) {
+            $e = new Event();
+            $e->setStatus(new Status('Available'));
+            $e->setStartDate(new \DateTime($subEvent['startDate']));
+            $e->setEndDate(new \DateTime($subEvent['endDate']));
+            $newEvents[] = $e;
+        }
+
+        $newEvents[1]->setStatus(new Status('Unavailable'));
+
+        $event->setSubEvents($newEvents);
+
+        $expectedOutput = 'Donderdag 9 november 2017'. PHP_EOL;
+        $expectedOutput .= 'Donderdag 16 november 2017 (geannuleerd)' . PHP_EOL;
+        $expectedOutput .= 'Donderdag 23 november 2017' . PHP_EOL;
+        $expectedOutput .= 'Donderdag 30 november 2017';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
 }

--- a/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class MediumMultiplePlainTextFormatterTest extends TestCase
@@ -22,9 +23,11 @@ class MediumMultiplePlainTextFormatterTest extends TestCase
     {
         $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEvents.json'), true);
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $newEvents = array();
         foreach ($subEvents as $subEvent) {
             $e = new Event();
+            $e->setStatus(new Status('Available'));
             $e->setStartDate(new \DateTime($subEvent['startDate']));
             $e->setEndDate(new \DateTime($subEvent['endDate']));
             $newEvents[] = $e;
@@ -46,9 +49,11 @@ class MediumMultiplePlainTextFormatterTest extends TestCase
     {
         $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEventsMoreDays.json'), true);
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $newEvents = array();
         foreach ($subEvents as $subEvent) {
             $e = new Event();
+            $e->setStatus(new Status('Available'));
             $e->setStartDate(new \DateTime($subEvent['startDate']));
             $e->setEndDate(new \DateTime($subEvent['endDate']));
             $newEvents[] = $e;
@@ -59,6 +64,32 @@ class MediumMultiplePlainTextFormatterTest extends TestCase
         $expectedOutput .= 'Van dinsdag 14 november 2017 tot donderdag 16 november 2017' . PHP_EOL;
         $expectedOutput .= 'Van dinsdag 21 november 2017 tot donderdag 23 november 2017' . PHP_EOL;
         $expectedOutput .= 'Van dinsdag 28 november 2017 tot donderdag 30 november 2017';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextMultipleDateMediumOneDayWithUnavailableStatus(): void
+    {
+        $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEvents.json'), true);
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $newEvents = array();
+        foreach ($subEvents as $subEvent) {
+            $e = new Event();
+            $e->setStatus(new Status('Unavailable'));
+            $e->setStartDate(new \DateTime($subEvent['startDate']));
+            $e->setEndDate(new \DateTime($subEvent['endDate']));
+            $newEvents[] = $e;
+        }
+        $event->setSubEvents($newEvents);
+
+        $expectedOutput = 'Donderdag 9 november 2017 (geannuleerd)'. PHP_EOL;
+        $expectedOutput .= 'Donderdag 16 november 2017 (geannuleerd)' . PHP_EOL;
+        $expectedOutput .= 'Donderdag 23 november 2017 (geannuleerd)' . PHP_EOL;
+        $expectedOutput .= 'Donderdag 30 november 2017 (geannuleerd)';
 
         $this->assertEquals(
             $expectedOutput,

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class SmallMultiplePlainTextFormatterTest extends TestCase
@@ -21,6 +22,7 @@ class SmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatMultipleWithoutLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-11-2025'));
         $offer->setEndDate(new \DateTime('30-11-2030'));
 
@@ -33,6 +35,7 @@ class SmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatMultipleWithLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-03-2025'));
         $offer->setEndDate(new \DateTime('08-03-2030'));
 
@@ -42,10 +45,23 @@ class SmallMultiplePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-11-2025'));
+        $offer->setEndDate(new \DateTime('30-11-2030'));
+
+        $this->assertEquals(
+            'Van 25 november 2025 tot 30 november 2030 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
 
     public function testFormatMultipleDayWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-03-2025'));
         $offer->setEndDate(new \DateTime('30-03-2030'));
 
@@ -58,6 +74,7 @@ class SmallMultiplePlainTextFormatterTest extends TestCase
     public function testFormatMultipleMonthWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2030'));
 
@@ -67,14 +84,41 @@ class SmallMultiplePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleDayWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-03-2025'));
+        $offer->setEndDate(new \DateTime('30-03-2030'));
+
+        $this->assertEquals(
+            'Van 25 maart 2025 tot 30 maart 2030 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatAPeriodWithSameBeginAndEndDate(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('08-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2025'));
 
         $this->assertEquals(
             'Woensdag 8 oktober 2025',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodWithSameBeginAndEndDateWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('08-10-2025'));
+        $offer->setEndDate(new \DateTime('08-10-2025'));
+
+        $this->assertEquals(
+            'Woensdag 8 oktober 2025 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,6 +26,7 @@ class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithoutLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-11-2025'));
         $offer->setEndDate(new \DateTime('30-11-2030'));
 
@@ -37,6 +39,7 @@ class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-03-2025'));
         $offer->setEndDate(new \DateTime('08-03-2030'));
 
@@ -46,9 +49,23 @@ class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatAPeriodWithoutLeadingZeroesWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-11-2025'));
+        $offer->setEndDate(new \DateTime('30-11-2030'));
+
+        $this->assertEquals(
+            'Vanaf 25/11/25 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatAPeriodDayWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-03-2025'));
         $offer->setEndDate(new \DateTime('30-03-2030'));
 
@@ -61,6 +78,7 @@ class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodMonthWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2030'));
 
@@ -73,11 +91,25 @@ class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodThatHasAlreadyStarted(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('12-03-2015'));
         $offer->setEndDate(new \DateTime('18-03-2030'));
 
         $this->assertEquals(
             'Tot 18/3/30',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodThatHasAlreadyStartedWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('12-03-2015'));
+        $offer->setEndDate(new \DateTime('18-03-2030'));
+
+        $this->assertEquals(
+            'Tot 18/3/30 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
@@ -7,10 +7,6 @@ use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Provide unit tests for large plain text periodic formatter.
- * @package CultuurNet\CalendarSummaryV3\Periodic
- */
 class LargePeriodicPlainTextFormatterTest extends TestCase
 {
     /**

--- a/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
@@ -3,8 +3,10 @@
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\Translator;
+use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\OpeningHours;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class LargePeriodicPlainTextFormatterTest extends TestCase
@@ -22,6 +24,7 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithSingleTimeBlocks(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -50,9 +53,42 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatAPeriodWithSingleTimeBlocksWithUnavailableStatus(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $event->setStartDate(new \DateTime('25-11-2025'));
+        $event->setEndDate(new \DateTime('30-11-2030'));
+
+        $openingHours1 = new OpeningHours();
+        $openingHours1->setDaysOfWeek(['monday','tuesday', 'wednesday']);
+        $openingHours1->setOpens('00:01');
+        $openingHours1->setCloses('17:00');
+
+        $openingHours2 = new OpeningHours();
+        $openingHours2->setDaysOfWeek(['friday', 'saturday']);
+        $openingHours2->setOpens('10:00');
+        $openingHours2->setCloses('18:00');
+
+        $openingHoursData = [$openingHours1, $openingHours2];
+
+        $event->setOpeningHours($openingHoursData);
+
+        $this->assertEquals(
+            'Van 25 november 2025 tot 30 november 2030'. PHP_EOL
+            . '(maandag van 0:01 tot 17:00, '
+            . 'dinsdag van 0:01 tot 17:00, '
+            . 'woensdag van 0:01 tot 17:00, '
+            . 'vrijdag van 10:00 tot 18:00, '
+            . 'zaterdag van 10:00 tot 18:00) (geannuleerd)',
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatAPeriodWithSplitTimeBlocks(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -94,6 +130,7 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithComplexTimeBlocks(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
@@ -139,12 +176,26 @@ class LargePeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithoutTimeBlocks(): void
     {
         $place = new Place();
+        $place->setStatus(new Status('Available'));
         $place->setStartDate(new \DateTime('25-11-2025'));
         $place->setEndDate(new \DateTime('30-11-2030'));
 
         $this->assertEquals(
             'Van 25 november 2025 tot 30 november 2030',
             $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatAPeriodWithoutTimeBlocksWithStatusUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $event->setStartDate(new \DateTime('25-11-2025'));
+        $event->setEndDate(new \DateTime('30-11-2030'));
+
+        $this->assertEquals(
+            'Van 25 november 2025 tot 30 november 2030 (geannuleerd)',
+            $this->formatter->format($event)
         );
     }
 }

--- a/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,6 +26,7 @@ class MediumPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithoutLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-11-2025'));
         $offer->setEndDate(new \DateTime('30-11-2030'));
 
@@ -37,6 +39,7 @@ class MediumPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-03-2025'));
         $offer->setEndDate(new \DateTime('08-03-2030'));
 
@@ -46,10 +49,23 @@ class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatAPeriodWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-11-2025'));
+        $offer->setEndDate(new \DateTime('30-11-2030'));
+
+        $this->assertEquals(
+            'Van 25 november 2025 tot 30 november 2030 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
 
     public function testFormatAPeriodDayWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-03-2025'));
         $offer->setEndDate(new \DateTime('30-03-2030'));
 
@@ -62,6 +78,7 @@ class MediumPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodMonthWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2030'));
 
@@ -71,14 +88,41 @@ class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatAPeriodDayWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-03-2025'));
+        $offer->setEndDate(new \DateTime('30-03-2030'));
+
+        $this->assertEquals(
+            'Van 25 maart 2025 tot 30 maart 2030 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatAPeriodWithSameBeginAndEndDate(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('08-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2025'));
 
         $this->assertEquals(
             'Woensdag 8 oktober 2025',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodWithSameBeginAndEndDatWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('08-10-2025'));
+        $offer->setEndDate(new \DateTime('08-10-2025'));
+
+        $this->assertEquals(
+            'Woensdag 8 oktober 2025 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,6 +26,7 @@ class SmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithoutLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-11-2025'));
         $offer->setEndDate(new \DateTime('30-11-2030'));
 
@@ -37,6 +39,7 @@ class SmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodWithLeadingZeroes(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-03-2025'));
         $offer->setEndDate(new \DateTime('08-03-2030'));
 
@@ -46,9 +49,23 @@ class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatAPeriodWithoutLeadingZeroesWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('25-11-2025'));
+        $offer->setEndDate(new \DateTime('30-11-2030'));
+
+        $this->assertEquals(
+            'Vanaf 25 nov 2025 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatAPeriodDayWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('25-03-2025'));
         $offer->setEndDate(new \DateTime('30-03-2030'));
 
@@ -61,6 +78,7 @@ class SmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodMonthWithoutLeadingZero(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('04-10-2025'));
         $offer->setEndDate(new \DateTime('08-10-2030'));
 
@@ -73,11 +91,25 @@ class SmallPeriodicPlainTextFormatterTest extends TestCase
     public function testFormatAPeriodThatHasAlreadyStarted(): void
     {
         $offer = new Event();
+        $offer->setStatus(new Status('Available'));
         $offer->setStartDate(new \DateTime('12-03-2015'));
         $offer->setEndDate(new \DateTime('18-03-2030'));
 
         $this->assertEquals(
             'Tot 18 mrt 2030',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodThatHasAlreadyStartedWithUnavailableStatus(): void
+    {
+        $offer = new Event();
+        $offer->setStatus(new Status('Unavailable'));
+        $offer->setStartDate(new \DateTime('12-03-2015'));
+        $offer->setEndDate(new \DateTime('18-03-2030'));
+
+        $this->assertEquals(
+            'Tot 18 mrt 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Single/LargeSinglePlainTextFormatterTest.php
+++ b/tests/Single/LargeSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class LargeSinglePlainTextFormatterTest extends TestCase
@@ -22,6 +23,7 @@ class LargeSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateLargeOneDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
 
@@ -36,6 +38,7 @@ class LargeSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateLargeWithLeadingZeroOneDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-08T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-08T21:30:00+01:00'));
 
@@ -47,9 +50,25 @@ class LargeSinglePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPlainTextSingleDateLargeOneDayWithUnavailableStatus(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
+
+        $expectedOutput = 'Donderdag 25 januari 2018 van 20:00 tot 21:30 (geannuleerd)';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatPlainTextSingleDateLargeMoreDays(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-28T21:30:00+01:00'));
 
@@ -64,6 +83,7 @@ class LargeSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateLargeWithLeadingZeroMoreDays(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-06T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-08T21:30:00+01:00'));
 
@@ -78,6 +98,7 @@ class LargeSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateLargeWholeDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-06T00:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-06T23:59:59+01:00'));
 
@@ -92,6 +113,7 @@ class LargeSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateLargeSameTime(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-06T13:30:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-06T13:30:00+01:00'));
 

--- a/tests/Single/MediumSinglePlainTextFormatterTest.php
+++ b/tests/Single/MediumSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class MediumSinglePlainTextFormatterTest extends TestCase
@@ -21,6 +22,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
     public function testFormatHTMLSingleDateMediumOneDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
 
@@ -33,6 +35,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
     public function testFormatHTMLSingleDateMediumWithLeadingZeroOneDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-08T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-08T21:30:00+01:00'));
 
@@ -45,6 +48,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
     public function testFormatHTMLSingleDateMediumMoreDays(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-27T21:30:00+01:00'));
 
@@ -57,11 +61,38 @@ class MediumSinglePlainTextFormatterTest extends TestCase
     public function testFormatHTMLSingleDateMediumWithLeadingZeroMoreDays(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-06T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-08T21:30:00+01:00'));
 
         $this->assertEquals(
             'Van zaterdag 6 januari 2018 tot maandag 8 januari 2018',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHTMLSingleDateMediumOneDayWithUnavailableStatus(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
+
+        $this->assertEquals(
+            'Donderdag 25 januari 2018 (geannuleerd)',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHTMLSingleDateMediumOneDayWithTemporarilyUnavailableStatus(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
+
+        $this->assertEquals(
+            'Donderdag 25 januari 2018 (uitgesteld)',
             $this->formatter->format($event)
         );
     }

--- a/tests/Single/MediumSinglePlainTextFormatterTest.php
+++ b/tests/Single/MediumSinglePlainTextFormatterTest.php
@@ -19,7 +19,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
         $this->formatter = new MediumSinglePlainTextFormatter(new Translator('nl_NL'));
     }
 
-    public function testFormatHTMLSingleDateMediumOneDay(): void
+    public function testFormatPlainTextSingleDateMediumOneDay(): void
     {
         $event = new Event();
         $event->setStatus(new Status('Available'));
@@ -32,7 +32,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
         );
     }
 
-    public function testFormatHTMLSingleDateMediumWithLeadingZeroOneDay(): void
+    public function testFormatPlainTextSingleDateMediumWithLeadingZeroOneDay(): void
     {
         $event = new Event();
         $event->setStatus(new Status('Available'));
@@ -45,7 +45,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
         );
     }
 
-    public function testFormatHTMLSingleDateMediumMoreDays(): void
+    public function testFormatPlainTextSingleDateMediumMoreDays(): void
     {
         $event = new Event();
         $event->setStatus(new Status('Available'));
@@ -58,7 +58,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
         );
     }
 
-    public function testFormatHTMLSingleDateMediumWithLeadingZeroMoreDays(): void
+    public function testFormatPlainTextSingleDateMediumWithLeadingZeroMoreDays(): void
     {
         $event = new Event();
         $event->setStatus(new Status('Available'));
@@ -71,7 +71,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
         );
     }
 
-    public function testFormatHTMLSingleDateMediumOneDayWithUnavailableStatus(): void
+    public function testFormatPlainTextSingleDateMediumOneDayWithUnavailableStatus(): void
     {
         $event = new Event();
         $event->setStatus(new Status('Unavailable'));
@@ -84,7 +84,7 @@ class MediumSinglePlainTextFormatterTest extends TestCase
         );
     }
 
-    public function testFormatHTMLSingleDateMediumOneDayWithTemporarilyUnavailableStatus(): void
+    public function testFormatPlainTextSingleDateMediumOneDayWithTemporarilyUnavailableStatus(): void
     {
         $event = new Event();
         $event->setStatus(new Status('TemporarilyUnavailable'));

--- a/tests/Single/SmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/SmallSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\SearchV3\ValueObjects\Event;
+use CultuurNet\SearchV3\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class SmallSinglePlainTextFormatterTest extends TestCase
@@ -21,6 +22,7 @@ class SmallSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateXsOneDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
 
@@ -33,6 +35,7 @@ class SmallSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateXsWithLeadingZeroOneDay(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-08T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-08T21:30:00+01:00'));
 
@@ -45,6 +48,7 @@ class SmallSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateXsMoreDays(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-28T21:30:00+01:00'));
 
@@ -57,11 +61,64 @@ class SmallSinglePlainTextFormatterTest extends TestCase
     public function testFormatPlainTextSingleDateXsWithLeadingZeroMoreDays(): void
     {
         $event = new Event();
+        $event->setStatus(new Status('Available'));
         $event->setStartDate(new \DateTime('2018-01-06T20:00:00+01:00'));
         $event->setEndDate(new \DateTime('2018-01-08T21:30:00+01:00'));
 
         $this->assertEquals(
             'Van 6 jan tot 8 jan',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsOneDayWithStatusUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
+
+        $this->assertEquals(
+            '25 jan (geannuleerd)',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsOneDayWithStatusTemporarilyUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-25T21:30:00+01:00'));
+
+        $this->assertEquals(
+            '25 jan (uitgesteld)',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsMoreDaysWithStatusUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('Unavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-28T21:30:00+01:00'));
+
+        $this->assertEquals(
+            'Van 25 jan tot 28 jan (geannuleerd)',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsMoreDaysWithStatusTemporarilyUnavailable(): void
+    {
+        $event = new Event();
+        $event->setStatus(new Status('TemporarilyUnavailable'));
+        $event->setStartDate(new \DateTime('2018-01-25T20:00:00+01:00'));
+        $event->setEndDate(new \DateTime('2018-01-28T21:30:00+01:00'));
+
+        $this->assertEquals(
+            'Van 25 jan tot 28 jan (uitgesteld)',
             $this->formatter->format($event)
         );
     }


### PR DESCRIPTION
### Changed
- Offer status is now taken into account for plain text rendering of calendar type "Single"
- Offer status is now taken into account for plain text rendering of calendar type "Multiple"
- Offer status is now taken into account for plain text rendering of calendar type "Periodic"
