### PR TITLE
Create offertype from context

### DIFF
--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -62,7 +62,7 @@ final class Offer
         $data = json_decode($json, true);
 
         $offer = new self(
-            new OfferType(strtolower($data['@type'])),
+            OfferType::fromContext(strtolower($data['@context'])),
             Status::fromArray($data['status']),
             isset($data['startDate']) ? new DateTimeImmutable($data['startDate']) : null,
             isset($data['endDate']) ? new DateTimeImmutable($data['endDate']) : null,

--- a/src/Offer/OfferType.php
+++ b/src/Offer/OfferType.php
@@ -29,6 +29,19 @@ final class OfferType
         $this->value = $value;
     }
 
+    public static function fromContext(string $context): self
+    {
+        if ($context === '/contexts/place') {
+            return self::place();
+        }
+
+        if ($context === '/contexts/event') {
+            return self::event();
+        }
+
+        throw new InvalidArgumentException('Unknown context: ' . $context);
+    }
+
     public static function event(): self
     {
         return new self(self::EVENT);

--- a/tests/Offer/OfferTypeTest.php
+++ b/tests/Offer/OfferTypeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3\Offer;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class OfferTypeTest extends TestCase
+{
+    public function it_can_create_place_offer_type_from_context(): void
+    {
+        $this->assertEquals(
+            OfferType::fromContext('/contexts/place'),
+            OfferType::place()
+        );
+    }
+
+    public function it_can_create_event_offer_type_from_context(): void
+    {
+        $this->assertEquals(
+            OfferType::fromContext('/contexts/event'),
+            OfferType::event()
+        );
+    }
+
+    public function it_cannot_create_offer_type_from_invalid_context(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->assertEquals(
+            OfferType::fromContext('/contexts/NOT_A_VALID_CONTEXT'),
+            OfferType::event()
+        );
+    }
+}

--- a/tests/Offer/data/offer-with-opening-hours.json
+++ b/tests/Offer/data/offer-with-opening-hours.json
@@ -1,5 +1,5 @@
 {
-  "@type": "Place",
+  "@context": "/contexts/place",
   "calendarType":"periodic",
   "startDate": "2021-03-01T23:00:00+00:00",
   "endDate": "2021-03-28T22:59:59+00:00",

--- a/tests/Offer/data/offer-with-subevents.json
+++ b/tests/Offer/data/offer-with-subevents.json
@@ -1,5 +1,5 @@
 {
-  "@type": "Event",
+  "@context": "/contexts/event",
   "calendarType":"multiple",
   "startDate": "2021-03-01T23:00:00+00:00",
   "endDate": "2021-03-28T22:59:59+00:00",

--- a/tests/Offer/data/offer.json
+++ b/tests/Offer/data/offer.json
@@ -1,5 +1,5 @@
 {
-  "@type": "Event",
+  "@context": "/contexts/event",
   "calendarType":"single",
   "startDate": "2021-03-01T23:00:00+00:00",
   "endDate": "2021-03-28T22:59:59+00:00",

--- a/tests/Offer/data/permanent.json
+++ b/tests/Offer/data/permanent.json
@@ -1,5 +1,5 @@
 {
-  "@type": "Event",
+  "@context": "/contexts/event",
   "calendarType":"permanent",
   "status": {
     "type": "Available"


### PR DESCRIPTION
### Fixed
- OfferType is now created from the always available `@context` attribute instead of `@type` which can be absent
