### PR TITLE
III-4200 Include booking availability in calendar summary

### DIFF
--- a/src/HtmlAvailabilityFormatter.php
+++ b/src/HtmlAvailabilityFormatter.php
@@ -128,7 +128,7 @@ final class HtmlAvailabilityFormatter
                 $this->translator->translate('postponed');
         }
 
-        if ($this->bookingAvailability->getType() === 'Unavailable') {
+        if (!$this->bookingAvailability->isAvailable()) {
             return $this->translator->translate('sold_out');
         }
 

--- a/src/HtmlAvailabilityFormatter.php
+++ b/src/HtmlAvailabilityFormatter.php
@@ -7,7 +7,7 @@ namespace CultuurNet\CalendarSummaryV3;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
 
-final class HtmlStatusFormatter
+final class HtmlAvailabilityFormatter
 {
     /**
      * @var Translator

--- a/src/HtmlAvailabilityFormatter.php
+++ b/src/HtmlAvailabilityFormatter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
 
@@ -15,9 +16,19 @@ final class HtmlAvailabilityFormatter
     private $translator;
 
     /**
+     * @var bool
+     */
+    private $isAvailable;
+
+    /**
      * @var Status
      */
     private $status;
+
+    /**
+     * @var BookingAvailability
+     */
+    private $bookingAvailability;
 
     /**
      * @var string
@@ -47,7 +58,9 @@ final class HtmlAvailabilityFormatter
     public static function forOffer(Offer $offer, Translator $translator): self
     {
         $formatter = new self($translator);
+        $formatter->isAvailable = $offer->isAvailable();
         $formatter->status = $offer->getStatus();
+        $formatter->bookingAvailability = $offer->getBookingAvailability();
         $formatter->isPlace = $offer->isPlace();
         return $formatter;
     }
@@ -82,26 +95,26 @@ final class HtmlAvailabilityFormatter
 
     public function toString(): string
     {
-        if ($this->status->getType() === 'Available') {
+        if ($this->isAvailable) {
             return '';
         }
 
         $openTag = '<' . $this->element . ' ' . $this->getReasonAsTitleAttribute() . 'class="cf-status">';
         $closingTag = '</' . $this->element . '>';
-        $statusText = $this->getStatusText();
+        $availabilityText = $this->getAvailabilityText();
 
         if ($this->capitalize) {
-            $statusText = ucfirst($statusText);
+            $availabilityText = ucfirst($availabilityText);
         }
 
         if ($this->withBraces) {
-            $statusText = '(' . $statusText . ')';
+            $availabilityText = '(' . $availabilityText . ')';
         }
 
-        return $openTag . $statusText . $closingTag;
+        return $openTag . $availabilityText . $closingTag;
     }
 
-    private function getStatusText(): string
+    private function getAvailabilityText(): string
     {
         if ($this->isPlace) {
             return $this->status->getType() === 'Unavailable' ?
@@ -109,9 +122,17 @@ final class HtmlAvailabilityFormatter
                 $this->translator->translate('temporarily_closed');
         }
 
-        return $this->status->getType() === 'Unavailable' ?
-            $this->translator->translate('cancelled') :
-            $this->translator->translate('postponed');
+        if ($this->status->getType() !== 'Available') {
+            return $this->status->getType() === 'Unavailable' ?
+                $this->translator->translate('cancelled') :
+                $this->translator->translate('postponed');
+        }
+
+        if ($this->bookingAvailability->getType() === 'Unavailable') {
+            return $this->translator->translate('sold_out');
+        }
+
+        return '';
     }
 
     private function getReasonAsTitleAttribute(): string

--- a/src/Middleware/NonAvailablePlaceHTMLFormatter.php
+++ b/src/Middleware/NonAvailablePlaceHTMLFormatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Middleware;
 
 use Closure;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 
@@ -26,7 +26,7 @@ final class NonAvailablePlaceHTMLFormatter implements FormatterMiddleware
     public function format(Offer $offer, Closure $next): string
     {
         if ($this->appliesToOffer($offer)) {
-            return HtmlStatusFormatter::forOffer($offer, $this->translator)
+            return HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
                 ->withElement('span')
                 ->withoutBraces()
                 ->capitalize()

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Translator;
 use DateTimeZone;
@@ -43,10 +43,10 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
                 '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateTo) . '</span>';
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 }

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -37,14 +37,14 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
         if (DateComparison::onSameDay($startDate, $endDate)) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->append($this->formatter->formatAsShortDate($startDate))
-                ->appendStatus($offer->getStatus())
+                ->appendAvailability($offer->getStatus())
                 ->toString();
         }
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->from($this->formatter->formatAsShortDate($startDate))
             ->till($this->formatter->formatAsShortDate($endDate))
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 }

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -37,14 +37,14 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
         if (DateComparison::onSameDay($startDate, $endDate)) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->append($this->formatter->formatAsShortDate($startDate))
-                ->appendAvailability($offer->getStatus())
+                ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
                 ->toString();
         }
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->from($this->formatter->formatAsShortDate($startDate))
             ->till($this->formatter->formatAsShortDate($endDate))
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 }

--- a/src/Offer/BookingAvailability.php
+++ b/src/Offer/BookingAvailability.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3\Offer;
+
+use InvalidArgumentException;
+
+final class BookingAvailability
+{
+    private const AVAILABLE = 'Available';
+    private const UNAVAILABLE = 'Unavailable';
+
+    private const ALLOWED_TYPES = [
+        self::AVAILABLE,
+        self::UNAVAILABLE,
+    ];
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    public function __construct(string $type)
+    {
+        if (!in_array($type, self::ALLOWED_TYPES)) {
+            throw new InvalidArgumentException('Invalid status type: ' . $type);
+        }
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string[] $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self($data['type']);
+    }
+}

--- a/src/Offer/BookingAvailability.php
+++ b/src/Offer/BookingAvailability.php
@@ -34,6 +34,11 @@ final class BookingAvailability
         return $this->type;
     }
 
+    public function isAvailable(): bool
+    {
+        return $this->type === self::AVAILABLE;
+    }
+
     /**
      * @param string[] $data
      */

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -173,7 +173,7 @@ final class Offer
 
     public function isAvailable(): bool
     {
-        return $this->status->getType() === 'Available' && $this->bookingAvailability->getType() === 'Available';
+        return $this->status->getType() === 'Available' && $this->bookingAvailability->isAvailable();
     }
 
     public function getStartDate(): ?DateTimeImmutable

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -19,6 +19,11 @@ final class Offer
     private $status;
 
     /**
+     * @var BookingAvailability
+     */
+    private $bookingAvailability;
+
+    /**
      * @var DateTimeImmutable|null
      */
     private $startDate;
@@ -46,12 +51,14 @@ final class Offer
     public function __construct(
         OfferType $offerType,
         Status $status,
+        BookingAvailability $bookingAvailability,
         ?DateTimeImmutable $startDate = null,
         ?DateTimeImmutable $endDate = null,
         ?CalendarType $calendarType = null
     ) {
         $this->offerType = $offerType;
         $this->status = $status;
+        $this->bookingAvailability = $bookingAvailability;
         $this->startDate = $startDate;
         $this->endDate = $endDate;
         $this->calendarType = $calendarType;
@@ -64,6 +71,7 @@ final class Offer
         $offer = new self(
             OfferType::fromContext(strtolower($data['@context'])),
             Status::fromArray($data['status']),
+            BookingAvailability::fromArray($data['bookingAvailability']),
             isset($data['startDate']) ? new DateTimeImmutable($data['startDate']) : null,
             isset($data['endDate']) ? new DateTimeImmutable($data['endDate']) : null,
             new CalendarType($data['calendarType'])
@@ -90,6 +98,7 @@ final class Offer
             $subEvents[] = new self(
                 OfferType::event(),
                 Status::fromArray($subEventData['status']),
+                BookingAvailability::fromArray($subEventData['bookingAvailability']),
                 new DateTimeImmutable($subEventData['startDate']),
                 new DateTimeImmutable($subEventData['endDate'])
             );

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -146,10 +146,12 @@ final class Offer
         return $clone;
     }
 
-    public function withStatus(Status $status): self
+    public function withAvailability(Status $status, BookingAvailability $bookingAvailability): self
     {
         $clone = clone $this;
+
         $clone->status = $status;
+        $clone->bookingAvailability = $bookingAvailability;
 
         return $clone;
     }

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -164,6 +164,11 @@ final class Offer
         return $this->status;
     }
 
+    public function getBookingAvailability(): BookingAvailability
+    {
+        return $this->bookingAvailability;
+    }
+
     public function getStartDate(): ?DateTimeImmutable
     {
         return $this->startDate;

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -169,6 +169,11 @@ final class Offer
         return $this->bookingAvailability;
     }
 
+    public function isAvailable(): bool
+    {
+        return $this->status->getType() === 'Available' && $this->bookingAvailability->getType() === 'Available';
+    }
+
     public function getStartDate(): ?DateTimeImmutable
     {
         return $this->startDate;

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
@@ -41,11 +41,11 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
             $output = $this->formatStarted($endDate);
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 
     private function formatStarted(DateTimeInterface $endDate): string

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -36,14 +36,14 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
         if (DateComparison::inTheFuture($startDate)) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->fromPeriod($this->formatter->formatAsShortDate($startDate))
-                ->appendStatus($offer->getStatus())
+                ->appendAvailability($offer->getStatus())
                 ->toString();
         }
 
         $endDate = $offer->getEndDate();
         return PlainTextSummaryBuilder::start($this->translator)
             ->till($this->formatter->formatAsShortDate($endDate))
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 }

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -36,14 +36,14 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
         if (DateComparison::inTheFuture($startDate)) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->fromPeriod($this->formatter->formatAsShortDate($startDate))
-                ->appendAvailability($offer->getStatus())
+                ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
                 ->toString();
         }
 
         $endDate = $offer->getEndDate();
         return PlainTextSummaryBuilder::start($this->translator)
             ->till($this->formatter->formatAsShortDate($endDate))
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 }

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\OpeningHour;
 use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
@@ -32,14 +32,14 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
 
     public function format(Offer $offer): string
     {
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
         $output = $this->generateDates(
             $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get())),
             $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get())),
-            $optionalStatus
+            $optionalAvailability
         );
 
         if ($offer->getOpeningHours()) {

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -48,7 +48,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
                 ->append($this->generateWeekScheme($offer->getOpeningHours()));
         }
 
-        return $summary->appendAvailability($offer->getStatus())->toString();
+        return $summary->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())->toString();
     }
 
     /**

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -48,7 +48,7 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
                 ->append($this->generateWeekScheme($offer->getOpeningHours()));
         }
 
-        return $summary->appendStatus($offer->getStatus())->toString();
+        return $summary->appendAvailability($offer->getStatus())->toString();
     }
 
     /**

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 
@@ -47,10 +47,10 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
                 . '</span> <span class="cf-date">' . $intlDateTo . '</span>';
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 }

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -41,14 +41,14 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
         if ($formattedStartDate === $formattedEndDate) {
             return $summaryBuilder->append($formattedStartDayOfWeek)
                 ->append($formattedStartDate)
-                ->appendStatus($offer->getStatus())
+                ->appendAvailability($offer->getStatus())
                 ->toString();
         }
 
         return $summaryBuilder
             ->from($formattedStartDate)
             ->till($formattedEndDate)
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 }

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -41,14 +41,14 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
         if ($formattedStartDate === $formattedEndDate) {
             return $summaryBuilder->append($formattedStartDayOfWeek)
                 ->append($formattedStartDate)
-                ->appendAvailability($offer->getStatus())
+                ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
                 ->toString();
         }
 
         return $summaryBuilder
             ->from($formattedStartDate)
             ->till($formattedEndDate)
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 }

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
@@ -41,11 +41,11 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
             $output = $this->formatStarted($endDate);
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 
     private function formatStarted(DateTimeInterface $endDate): string

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -37,14 +37,14 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         if (DateComparison::inTheFuture($startDate)) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->fromPeriod($this->formatDate($startDate))
-                ->appendAvailability($offer->getStatus())
+                ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
                 ->toString();
         }
 
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         return PlainTextSummaryBuilder::start($this->translator)
             ->till($this->formatDate($endDate))
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -37,14 +37,14 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         if (DateComparison::inTheFuture($startDate)) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->fromPeriod($this->formatDate($startDate))
-                ->appendStatus($offer->getStatus())
+                ->appendAvailability($offer->getStatus())
                 ->toString();
         }
 
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         return PlainTextSummaryBuilder::start($this->translator)
             ->till($this->formatDate($endDate))
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\OpeningHour;
 use CultuurNet\CalendarSummaryV3\OpeningHourFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
@@ -42,8 +42,8 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
-        if ($offer->getStatus()->getType() !== 'Available') {
-            return HtmlStatusFormatter::forOffer($offer, $this->translator)
+        if ($offer->getStatus()->getType() !== 'Available' || $offer->getBookingAvailability()->getType() !== 'Available') {
+            return HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
                 ->withElement('p')
                 ->withoutBraces()
                 ->capitalize()

--- a/src/Permanent/LargePermanentHTMLFormatter.php
+++ b/src/Permanent/LargePermanentHTMLFormatter.php
@@ -42,7 +42,7 @@ final class LargePermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
-        if ($offer->getStatus()->getType() !== 'Available' || $offer->getBookingAvailability()->getType() !== 'Available') {
+        if (!$offer->isAvailable()) {
             return HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
                 ->withElement('p')
                 ->withoutBraces()

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\OpeningHour;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -31,8 +31,8 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
-        if ($offer->getStatus()->getType() !== 'Available') {
-            return HtmlStatusFormatter::forOffer($offer, $this->translator)
+        if ($offer->getStatus()->getType() !== 'Available' || $offer->getBookingAvailability()->getType() !== 'Available') {
+            return HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
                 ->withElement('p')
                 ->withoutBraces()
                 ->capitalize()

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -31,7 +31,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
 
     public function format(Offer $offer): string
     {
-        if ($offer->getStatus()->getType() !== 'Available' || $offer->getBookingAvailability()->getType() !== 'Available') {
+        if (!$offer->isAvailable()) {
             return HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
                 ->withElement('p')
                 ->withoutBraces()

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
 
 final class PlainTextSummaryBuilder
@@ -154,7 +155,7 @@ final class PlainTextSummaryBuilder
         return $lowercaseFirstCharacter ? lcfirst($formatted) : ucfirst($formatted);
     }
 
-    public function appendAvailability(Status $status): self
+    public function appendAvailability(Status $status, BookingAvailability $bookingAvailability): self
     {
         $c = clone $this;
 

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -154,7 +154,7 @@ final class PlainTextSummaryBuilder
         return $lowercaseFirstCharacter ? lcfirst($formatted) : ucfirst($formatted);
     }
 
-    public function appendStatus(Status $status): self
+    public function appendAvailability(Status $status): self
     {
         $c = clone $this;
 

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -167,6 +167,9 @@ final class PlainTextSummaryBuilder
                 $c->workingLine[] = '(' . $this->translator->translate('postponed') . ')';
                 return $c;
             default:
+                if ($bookingAvailability->getType() === 'Unavailable') {
+                    $c->workingLine[] = '(' . $this->translator->translate('sold_out') . ')';
+                }
                 return $c;
         }
     }

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -167,7 +167,7 @@ final class PlainTextSummaryBuilder
                 $c->workingLine[] = '(' . $this->translator->translate('postponed') . ')';
                 return $c;
             default:
-                if ($bookingAvailability->getType() === 'Unavailable') {
+                if (!$bookingAvailability->isAvailable()) {
                     $c->workingLine[] = '(' . $this->translator->translate('sold_out') . ')';
                 }
                 return $c;

--- a/src/Single/LargeSingleHTMLFormatter.php
+++ b/src/Single/LargeSingleHTMLFormatter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
@@ -40,11 +40,11 @@ final class LargeSingleHTMLFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($dateFrom, $dateEnd);
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 
     private function formatSameDay(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -42,7 +42,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 

--- a/src/Single/LargeSinglePlainTextFormatter.php
+++ b/src/Single/LargeSinglePlainTextFormatter.php
@@ -42,7 +42,7 @@ final class LargeSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
@@ -40,11 +40,11 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($dateFrom, $dateEnd);
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 
     private function formatSameDay(DateTimeInterface $dateFrom): string

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -42,7 +42,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -42,7 +42,7 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
-use CultuurNet\CalendarSummaryV3\HtmlStatusFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
@@ -40,11 +40,11 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
             $output = $this->formatMoreDays($dateFrom, $dateEnd);
         }
 
-        $optionalStatus = HtmlStatusFormatter::forOffer($offer, $this->translator)
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
             ->withBraces()
             ->toString();
 
-        return trim($output . ' ' . $optionalStatus);
+        return trim($output . ' ' . $optionalAvailability);
     }
 
     private function formatSameDay(DateTimeInterface $dateFrom): string

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -42,7 +42,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendStatus($offer->getStatus())
+            ->appendAvailability($offer->getStatus())
             ->toString();
     }
 

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -42,7 +42,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->append($output)
-            ->appendAvailability($offer->getStatus())
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -36,6 +36,7 @@ final class Translator
                 'cancelled' => 'cancelled',
                 'postponed' => 'postponed',
                 'event_concluded' => 'Event ended',
+                'sold_out' => 'Sold out or fully booked',
             ],
             'nl' => [
                 'from' => 'van',
@@ -51,6 +52,7 @@ final class Translator
                 'cancelled' => 'geannuleerd',
                 'postponed' => 'uitgesteld',
                 'event_concluded' => 'Evenement afgelopen',
+                'sold_out' => 'Volzet of uitverkocht',
             ],
             'fr' => [
                 'from' => 'du',
@@ -66,6 +68,7 @@ final class Translator
                 'cancelled' => 'annulé',
                 'postponed' => 'reporté',
                 'event_concluded' => 'Fin de l’événement',
+                'sold_out' => 'Complet',
             ],
             'de' => [
                 'from' => 'von',
@@ -81,6 +84,7 @@ final class Translator
                 'cancelled' => 'abgesagt',
                 'postponed' => 'verschoben',
                 'event_concluded' => 'Event abgeschlossen',
+                'sold_out' => 'Ausgebucht oder ausverkauft',
             ],
         ];
 

--- a/tests/CalendarHTMLFormatterTest.php
+++ b/tests/CalendarHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -28,6 +29,7 @@ final class CalendarHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00'),
             CalendarType::single()
@@ -44,6 +46,7 @@ final class CalendarHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00'),
             CalendarType::single()

--- a/tests/CalendarPlainTextFormatterTest.php
+++ b/tests/CalendarPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -28,6 +29,7 @@ final class CalendarPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00'),
             CalendarType::single()
@@ -41,6 +43,7 @@ final class CalendarPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00'),
             CalendarType::single()

--- a/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlaceHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Middleware;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -27,7 +28,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('Unavailable', [])
+            new Status('Unavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -44,7 +46,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('TemporarilyUnavailable', [])
+            new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -61,7 +64,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('Available', [])
+            new Status('Available', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -78,7 +82,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $event = new Offer(
             OfferType::event(),
-            new Status('TemporarilyUnavailable', [])
+            new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -95,7 +100,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $event = new Offer(
             OfferType::event(),
-            new Status('TemporarilyUnavailable', [])
+            new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -112,7 +118,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $event = new Offer(
             OfferType::event(),
-            new Status('Available', [])
+            new Status('Available', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -129,7 +136,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('Unavailable', ['nl' => 'Covid-19'])
+            new Status('Unavailable', ['nl' => 'Covid-19']),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -146,7 +154,8 @@ final class NonAvailablePlaceHTMLFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('Unavailable', ['fr' => "Désolé, c'est annulé!"])
+            new Status('Unavailable', ['fr' => "Désolé, c'est annulé!"]),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(

--- a/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
+++ b/tests/Middleware/NonAvailablePlacePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Middleware;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -27,7 +28,8 @@ final class NonAvailablePlacePlainTextFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('Unavailable', [])
+            new Status('Unavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -44,7 +46,8 @@ final class NonAvailablePlacePlainTextFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('TemporarilyUnavailable', [])
+            new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -61,7 +64,8 @@ final class NonAvailablePlacePlainTextFormatterTest extends TestCase
     {
         $place = new Offer(
             OfferType::place(),
-            new Status('Available', [])
+            new Status('Available', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -78,7 +82,8 @@ final class NonAvailablePlacePlainTextFormatterTest extends TestCase
     {
         $event = new Offer(
             OfferType::event(),
-            new Status('Unavailable', [])
+            new Status('Unavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -95,7 +100,8 @@ final class NonAvailablePlacePlainTextFormatterTest extends TestCase
     {
         $event = new Offer(
             OfferType::event(),
-            new Status('TemporarilyUnavailable', [])
+            new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(
@@ -112,7 +118,8 @@ final class NonAvailablePlacePlainTextFormatterTest extends TestCase
     {
         $event = new Offer(
             OfferType::event(),
-            new Status('Available', [])
+            new Status('Available', []),
+            new BookingAvailability('Available')
         );
 
         $result = $this->formatter->format(

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -46,6 +48,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::multiple()
@@ -63,6 +66,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -81,6 +85,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::multiple()
@@ -98,6 +103,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025 12:00'),
             new DateTimeImmutable('08-10-2025 14:00'),
             CalendarType::multiple()

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -80,6 +80,44 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleWithoutLeadingZeroesWithUnavailableStatusAndUnavailableBooking(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25/11/25</span> '
+            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30/11/30</span>'
+            . ' <span class="cf-status">(geannuleerd)</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleWithoutLeadingZeroesWithAvailableStatusAndUnavailableBooking(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25/11/25</span> '
+            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30/11/30</span>'
+            . ' <span class="cf-status">(Volzet of uitverkocht)</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatMultipleMonthWithoutLeadingZero(): void
     {
         $offer = new Offer(

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -45,6 +47,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::multiple()
@@ -61,6 +64,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -77,6 +81,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('30-11-2030'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -93,6 +98,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::multiple()
@@ -109,6 +115,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::multiple()
@@ -125,6 +132,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-03-2025'),
             new DateTimeImmutable('08-03-2025'),
             CalendarType::multiple()
@@ -141,6 +149,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::multiple()

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -160,4 +160,38 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
             $this->formatter->format($offer)
         );
     }
+
+    public function testFormatMultipleWithUnavailableStatusAndUnavailableBooking(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('04-10-2025'),
+            new DateTimeImmutable('08-10-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            'Van 4/10/25 tot 8/10/30 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleAvailableStatusAndUnavailableBooking(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('04-10-2025'),
+            new DateTimeImmutable('08-10-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            'Van 4/10/25 tot 8/10/30 (Volzet of uitverkocht)',
+            $this->formatter->format($offer)
+        );
+    }
 }

--- a/tests/Multiple/LargeMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/LargeMultipleHTMLFormatterTest.php
@@ -120,7 +120,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
         );
     }
 
-    public function testFormatHTMLMultipleDateLargeOneDayWithUnavailableStatus(): void
+    public function testFormatHTMLMultipleDateLargeOneDayWithUnavailability(): void
     {
         $subEvents = json_decode(file_get_contents(__DIR__ . '/data/subEvents.json'), true);
         $event = new Offer(
@@ -142,7 +142,14 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
                 new DateTimeImmutable($subEvent['endDate'])
             );
         }
-        $newEvents[1] = $newEvents[1]->withStatus(new Status('Unavailable', []));
+        $newEvents[1] = $newEvents[1]->withAvailability(
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable')
+        );
+        $newEvents[2] = $newEvents[2]->withAvailability(
+            new Status('Available', []),
+            new BookingAvailability('Unavailable')
+        );
         $event = $event->withSubEvents($newEvents);
 
         $expectedOutput = '<ul class="cnw-event-date-info"><li>';
@@ -190,7 +197,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
         $expectedOutput .= ' ';
         $expectedOutput .= '<time itemprop="endDate" datetime="2017-11-23T22:00:00+01:00">';
         $expectedOutput .= '<span class="cf-time">22:00</span>';
-        $expectedOutput .= '</time></li>';
+        $expectedOutput .= '</time> <span class="cf-status">(Volzet of uitverkocht)</span></li>';
         $expectedOutput .= '<li><time itemprop="startDate" datetime="2017-11-30T20:00:00+01:00">';
         $expectedOutput .= '<span class="cf-weekday cf-meta">Donderdag</span>';
         $expectedOutput .= ' ';

--- a/tests/Multiple/LargeMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/LargeMultipleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -32,6 +33,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -42,6 +44,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -123,6 +126,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -133,6 +137,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -214,6 +219,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -224,6 +230,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -341,6 +348,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -351,6 +359,7 @@ final class LargeMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );

--- a/tests/Multiple/LargeMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/LargeMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -31,6 +32,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -41,6 +43,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -72,6 +75,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -82,6 +86,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Unavailable', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -113,6 +118,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -123,6 +129,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -149,6 +156,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -159,6 +167,7 @@ final class LargeMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );

--- a/tests/Multiple/MediumMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/MediumMultipleHTMLFormatterTest.php
@@ -88,7 +88,14 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
                 new DateTimeImmutable($subEvent['endDate'])
             );
         }
-        $newEvents[1] = $newEvents[1]->withStatus(new Status('Unavailable', []));
+        $newEvents[1] = $newEvents[1]->withAvailability(
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable')
+        );
+        $newEvents[2] = $newEvents[2]->withAvailability(
+            new Status('Available', []),
+            new BookingAvailability('Unavailable')
+        );
         $event = $event->withSubEvents($newEvents);
 
         $expectedOutput = '<ul class="cnw-event-date-info"><li>';
@@ -97,7 +104,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
         $expectedOutput .= '<span class="cf-date">16 november 2017</span> <span class="cf-status">(geannuleerd)</span></li>';
         $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
-        $expectedOutput .= '<span class="cf-date">23 november 2017</span></li>';
+        $expectedOutput .= '<span class="cf-date">23 november 2017</span> <span class="cf-status">(Volzet of uitverkocht)</span></li>';
         $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
         $expectedOutput .= '<span class="cf-date">30 november 2017</span></li></ul>';
 

--- a/tests/Multiple/MediumMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/MediumMultipleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -40,6 +42,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -69,6 +72,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -79,6 +83,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -108,6 +113,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -118,6 +124,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -164,6 +171,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -174,6 +182,7 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );

--- a/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
@@ -156,13 +156,20 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
             );
         }
 
-        $newEvents[1] = $newEvents[1]->withStatus(new Status('Unavailable', []));
+        $newEvents[1] = $newEvents[1]->withAvailability(
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable')
+        );
+        $newEvents[2] = $newEvents[2]->withAvailability(
+            new Status('Available', []),
+            new BookingAvailability('Unavailable')
+        );
 
         $event = $event->withSubEvents($newEvents);
 
         $expectedOutput = 'Donderdag 9 november 2017' . PHP_EOL;
         $expectedOutput .= 'Donderdag 16 november 2017 (geannuleerd)' . PHP_EOL;
-        $expectedOutput .= 'Donderdag 23 november 2017' . PHP_EOL;
+        $expectedOutput .= 'Donderdag 23 november 2017 (Volzet of uitverkocht)' . PHP_EOL;
         $expectedOutput .= 'Donderdag 30 november 2017';
 
         $this->assertEquals(

--- a/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -40,6 +42,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -64,6 +67,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -74,6 +78,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -98,6 +103,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -108,6 +114,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Unavailable', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -132,6 +139,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -142,6 +150,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );
@@ -170,6 +179,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::multiple()
@@ -180,6 +190,7 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
             $newEvents[] = new Offer(
                 OfferType::event(),
                 new Status('Available', []),
+                new BookingAvailability('Available'),
                 new DateTimeImmutable($subEvent['startDate']),
                 new DateTimeImmutable($subEvent['endDate'])
             );

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -62,6 +62,25 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleWithoutLeadingZeroesWithAvailableStatusAndUnavailableBooking(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 november 2025</span> '
+            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 november 2030</span>'
+            . ' <span class="cf-status">(Volzet of uitverkocht)</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatMultipleWithLeadingZeroes(): void
     {
         $offer = new Offer(

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -46,6 +48,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -64,6 +67,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::multiple()
@@ -81,6 +85,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::multiple()
@@ -98,6 +103,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025'),
             new DateTimeImmutable('08-10-2025'),
             CalendarType::multiple()

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -45,6 +47,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::multiple()
@@ -61,6 +64,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::multiple()
@@ -77,6 +81,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::multiple()
@@ -93,6 +98,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::multiple()
@@ -109,6 +115,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::multiple()
@@ -125,6 +132,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025'),
             new DateTimeImmutable('08-10-2025'),
             CalendarType::multiple()
@@ -141,6 +149,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025'),
             new DateTimeImmutable('08-10-2025'),
             CalendarType::multiple()

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -21,6 +21,7 @@ final class OfferTest extends TestCase
                     'en' => 'Postponed',
                 ]
             ),
+            new BookingAvailability('Unavailable'),
             new DateTimeImmutable('2021-03-01T23:00:00+00:00'),
             new DateTimeImmutable('2021-03-28T22:59:59+00:00'),
             CalendarType::single()
@@ -35,6 +36,7 @@ final class OfferTest extends TestCase
         $expected = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -49,6 +51,7 @@ final class OfferTest extends TestCase
         $expected = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2021-03-01T23:00:00+00:00'),
             new DateTimeImmutable('2021-03-28T22:59:59+00:00'),
             CalendarType::multiple()
@@ -59,12 +62,14 @@ final class OfferTest extends TestCase
                 new Offer(
                     OfferType::event(),
                     new Status('Available', []),
+                    new BookingAvailability('Unavailable'),
                     new DateTimeImmutable('2021-03-01T23:00:00+00:00'),
                     new DateTimeImmutable('2021-03-14T22:59:59+00:00')
                 ),
                 new Offer(
                     OfferType::event(),
                     new Status('Available', []),
+                    new BookingAvailability('Available'),
                     new DateTimeImmutable('2021-03-15T23:00:00+00:00'),
                     new DateTimeImmutable('2021-03-28T22:59:59+00:00')
                 ),
@@ -80,6 +85,7 @@ final class OfferTest extends TestCase
         $expected = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2021-03-01T23:00:00+00:00'),
             new DateTimeImmutable('2021-03-28T22:59:59+00:00'),
             CalendarType::periodic()

--- a/tests/Offer/data/offer-with-opening-hours.json
+++ b/tests/Offer/data/offer-with-opening-hours.json
@@ -6,6 +6,9 @@
   "status": {
     "type": "Available"
   },
+  "bookingAvailability": {
+    "type": "Available"
+  },
   "openingHours": [
     {
       "opens":"08:00",

--- a/tests/Offer/data/offer-with-subevents.json
+++ b/tests/Offer/data/offer-with-subevents.json
@@ -6,18 +6,27 @@
   "status": {
     "type": "Available"
   },
+  "bookingAvailability": {
+    "type": "Available"
+  },
   "subEvent": [
     {
       "startDate": "2021-03-01T23:00:00+00:00",
       "endDate": "2021-03-14T22:59:59+00:00",
       "status": {
         "type": "Available"
+      },
+      "bookingAvailability": {
+        "type": "Unavailable"
       }
     },
     {
       "startDate": "2021-03-15T23:00:00+00:00",
       "endDate": "2021-03-28T22:59:59+00:00",
       "status": {
+        "type": "Available"
+      },
+      "bookingAvailability": {
         "type": "Available"
       }
     }

--- a/tests/Offer/data/offer.json
+++ b/tests/Offer/data/offer.json
@@ -9,5 +9,8 @@
       "nl": "Uitgesteld",
       "en": "Postponed"
     }
+  },
+  "bookingAvailability": {
+    "type": "Unavailable"
   }
 }

--- a/tests/Offer/data/permanent.json
+++ b/tests/Offer/data/permanent.json
@@ -3,5 +3,8 @@
   "calendarType":"permanent",
   "status": {
     "type": "Available"
+  },
+  "bookingAvailability": {
+    "type": "Available"
   }
 }

--- a/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -54,6 +56,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::periodic()
@@ -79,6 +82,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -106,6 +110,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -131,6 +136,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::periodic()
@@ -156,6 +162,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('12-03-2015'),
             new DateTimeImmutable('18-03-2030'),
             CalendarType::periodic()

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -45,6 +47,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::periodic()
@@ -61,6 +64,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -77,6 +81,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -93,6 +98,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::periodic()
@@ -109,6 +115,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('12-03-2015'),
             new DateTimeImmutable('18-03-2030'),
             CalendarType::periodic()
@@ -125,6 +132,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('12-03-2015'),
             new DateTimeImmutable('18-03-2030'),
             CalendarType::periodic()

--- a/tests/Periodic/LargePeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/LargePeriodicHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -111,6 +113,7 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -193,6 +196,7 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -304,6 +308,7 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -404,6 +409,7 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()

--- a/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -66,6 +68,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -102,6 +105,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -148,6 +152,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -198,6 +203,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -214,6 +220,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()

--- a/tests/Periodic/MediumPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -46,6 +48,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::periodic()
@@ -63,6 +66,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -81,6 +85,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -98,6 +103,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::periodic()
@@ -115,6 +121,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025'),
             new DateTimeImmutable('08-10-2025'),
             CalendarType::periodic()

--- a/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -45,6 +47,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::periodic()
@@ -61,6 +64,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -77,6 +81,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -93,6 +98,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::periodic()
@@ -109,6 +115,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -125,6 +132,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025'),
             new DateTimeImmutable('08-10-2025'),
             CalendarType::periodic()
@@ -141,6 +149,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('08-10-2025'),
             new DateTimeImmutable('08-10-2025'),
             CalendarType::periodic()

--- a/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -54,6 +56,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::periodic()
@@ -79,6 +82,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -106,6 +110,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -131,6 +136,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::periodic()
@@ -156,6 +162,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('12-03-2015'),
             new DateTimeImmutable('18-03-2030'),
             CalendarType::periodic()

--- a/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -29,6 +30,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -45,6 +47,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-03-2025'),
             new DateTimeImmutable('08-03-2030'),
             CalendarType::periodic()
@@ -61,6 +64,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030'),
             CalendarType::periodic()
@@ -77,6 +81,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-03-2025'),
             new DateTimeImmutable('30-03-2030'),
             CalendarType::periodic()
@@ -93,6 +98,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('04-10-2025'),
             new DateTimeImmutable('08-10-2030'),
             CalendarType::periodic()
@@ -109,6 +115,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('12-03-2015'),
             new DateTimeImmutable('18-03-2030'),
             CalendarType::periodic()
@@ -125,6 +132,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         $offer = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('12-03-2015'),
             new DateTimeImmutable('18-03-2030'),
             CalendarType::periodic()

--- a/tests/Permanent/LargePermanentHTMLFormatterTest.php
+++ b/tests/Permanent/LargePermanentHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -124,6 +126,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -242,6 +245,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -356,6 +360,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -372,6 +377,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -389,6 +395,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', ['nl' => 'Covid-19']),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -405,6 +412,7 @@ final class LargePermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', ['fr' => 'Sacre bleu']),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()

--- a/tests/Permanent/LargePermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/LargePermanentPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('30-11-2030')
         );
@@ -77,6 +79,7 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -131,6 +134,7 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -193,6 +197,7 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -209,6 +214,7 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -78,6 +80,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -132,6 +135,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -192,6 +196,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -208,6 +213,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -224,6 +230,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', ['nl' => 'Covid-19']),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -240,6 +247,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', ['fr' => 'Sacre bleu']),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()

--- a/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Permanent;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -30,6 +31,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -71,6 +73,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -119,6 +122,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         $place = new Offer(
             OfferType::place(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('25-11-2025'),
             new DateTimeImmutable('25-11-2025')
         );
@@ -174,6 +178,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()
@@ -190,6 +195,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             null,
             null,
             CalendarType::permanent()

--- a/tests/Single/LargeSingleHTMLFormatterTest.php
+++ b/tests/Single/LargeSingleHTMLFormatterTest.php
@@ -215,6 +215,54 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatHTMLSingleDateLargeWholeDayWithStatusUnavailableAndBookingUnavailable(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-06T00:00:00+01:00'),
+            new DateTimeImmutable('2018-01-06T23:59:59+01:00')
+        );
+
+        $expectedOutput = '<time itemprop="startDate" datetime="2018-01-06T00:00:00+01:00">';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">Zaterdag</span>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-date">6 januari 2018</span>';
+        $expectedOutput .= '</time>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-status">(geannuleerd)</span>';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHTMLSingleDateLargeWholeDayWithStatusAvailableAndBookingUnavailable(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-06T00:00:00+01:00'),
+            new DateTimeImmutable('2018-01-06T23:59:59+01:00')
+        );
+
+        $expectedOutput = '<time itemprop="startDate" datetime="2018-01-06T00:00:00+01:00">';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">Zaterdag</span>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-date">6 januari 2018</span>';
+        $expectedOutput .= '</time>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-status">(Volzet of uitverkocht)</span>';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatHTMLSingleDateSameTime(): void
     {
         $event = new Offer(

--- a/tests/Single/LargeSingleHTMLFormatterTest.php
+++ b/tests/Single/LargeSingleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -29,6 +30,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -60,6 +62,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-08T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -91,6 +94,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-28T21:30:00+01:00')
         );
@@ -130,6 +134,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -169,6 +174,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T00:00:00+01:00'),
             new DateTimeImmutable('2018-01-06T23:59:59+01:00')
         );
@@ -190,6 +196,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T00:00:00+01:00'),
             new DateTimeImmutable('2018-01-06T23:59:59+01:00')
         );
@@ -213,6 +220,7 @@ final class LargeSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T13:30:00+01:00'),
             new DateTimeImmutable('2018-01-06T13:30:00+01:00')
         );

--- a/tests/Single/LargeSinglePlainTextFormatterTest.php
+++ b/tests/Single/LargeSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -29,6 +30,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -46,6 +48,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-08T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -63,6 +66,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -80,6 +84,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-28T21:30:00+01:00')
         );
@@ -97,6 +102,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -114,6 +120,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T00:00:00+01:00'),
             new DateTimeImmutable('2018-01-06T23:59:59+01:00')
         );
@@ -131,6 +138,7 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T13:30:00+01:00'),
             new DateTimeImmutable('2018-01-06T13:30:00+01:00')
         );

--- a/tests/Single/LargeSinglePlainTextFormatterTest.php
+++ b/tests/Single/LargeSinglePlainTextFormatterTest.php
@@ -79,6 +79,42 @@ final class LargeSinglePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPlainTextSingleDateLargeOneDayWithUnavailableStatusAndUnavailableBooking(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
+            new DateTimeImmutable('2018-01-25T21:30:00+01:00')
+        );
+
+        $expectedOutput = 'Donderdag 25 januari 2018 van 20:00 tot 21:30 (geannuleerd)';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateLargeOneDayWithAvailableStatusAndUnavailableBooking(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
+            new DateTimeImmutable('2018-01-25T21:30:00+01:00')
+        );
+
+        $expectedOutput = 'Donderdag 25 januari 2018 van 20:00 tot 21:30 (Volzet of uitverkocht)';
+
+        $this->assertEquals(
+            $expectedOutput,
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatPlainTextSingleDateLargeMoreDays(): void
     {
         $event = new Offer(

--- a/tests/Single/MediumSingleHTMLFormatterTest.php
+++ b/tests/Single/MediumSingleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -28,6 +29,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -43,6 +45,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -58,6 +61,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-08T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -73,6 +77,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-28T21:30:00+01:00')
         );
@@ -100,6 +105,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );

--- a/tests/Single/MediumSinglePlainTextFormatterTest.php
+++ b/tests/Single/MediumSinglePlainTextFormatterTest.php
@@ -104,6 +104,38 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPlainTextSingleDateMediumOneDayWithUnavailableStatusAndUnavailableBooking(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
+            new DateTimeImmutable('2018-01-25T21:30:00+01:00')
+        );
+
+        $this->assertEquals(
+            'Donderdag 25 januari 2018 (geannuleerd)',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateMediumOneDayWithAvailableStatusAndUnavailableBooking(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
+            new DateTimeImmutable('2018-01-25T21:30:00+01:00')
+        );
+
+        $this->assertEquals(
+            'Donderdag 25 januari 2018 (Volzet of uitverkocht)',
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatPlainTextSingleDateMediumOneDayWithTemporarilyUnavailableStatus(): void
     {
         $event = new Offer(

--- a/tests/Single/MediumSinglePlainTextFormatterTest.php
+++ b/tests/Single/MediumSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -28,6 +29,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -43,6 +45,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-08T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -58,6 +61,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-27T21:30:00+01:00')
         );
@@ -73,6 +77,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -88,6 +93,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -103,6 +109,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );

--- a/tests/Single/SmallSingleHTMLFormatterTest.php
+++ b/tests/Single/SmallSingleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -28,6 +29,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -43,6 +45,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -58,6 +61,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', ['nl' => 'Covid-19']),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -73,6 +77,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-08T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -88,6 +93,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-27T21:30:00+01:00')
         );
@@ -115,6 +121,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-27T21:30:00+01:00')
         );
@@ -144,6 +151,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );

--- a/tests/Single/SmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/SmallSinglePlainTextFormatterTest.php
@@ -136,6 +136,38 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPlainTextSingleDateXsMoreDaysWithStatusUnavailableAndBookingUnavailable(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Unavailable', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
+            new DateTimeImmutable('2018-01-28T21:30:00+01:00')
+        );
+
+        $this->assertEquals(
+            'Van 25 jan tot 28 jan (geannuleerd)',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsMoreDaysWithStatusAvailableAndBookingUnavailable(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Unavailable'),
+            new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
+            new DateTimeImmutable('2018-01-28T21:30:00+01:00')
+        );
+
+        $this->assertEquals(
+            'Van 25 jan tot 28 jan (Volzet of uitverkocht)',
+            $this->formatter->format($event)
+        );
+    }
+
     public function testFormatPlainTextSingleDateXsMoreDaysWithStatusTemporarilyUnavailable(): void
     {
         $event = new Offer(

--- a/tests/Single/SmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/SmallSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
@@ -28,6 +29,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -43,6 +45,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-08T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -58,6 +61,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-28T21:30:00+01:00')
         );
@@ -73,6 +77,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-06T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-08T21:30:00+01:00')
         );
@@ -88,6 +93,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -103,6 +109,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-25T21:30:00+01:00')
         );
@@ -118,6 +125,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('Unavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-28T21:30:00+01:00')
         );
@@ -133,6 +141,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
         $event = new Offer(
             OfferType::event(),
             new Status('TemporarilyUnavailable', []),
+            new BookingAvailability('Available'),
             new DateTimeImmutable('2018-01-25T20:00:00+01:00'),
             new DateTimeImmutable('2018-01-28T21:30:00+01:00')
         );


### PR DESCRIPTION
### Changed
- Include booking availability only when booking is `unavailable` and status is `available`

Note: Availability was introduced as a concept that combines both the status and the booking. An offer is unavailable when either the status or the booking is unavailable

---

Ticket: https://jira.uitdatabank.be/browse/III-4200
