### PR TITLE
III4498 changes calendarType Multiple

### DIFF
--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -35,8 +35,8 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
         $dateTo = $offer->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         if (DateComparison::onSameDay($dateFrom, $dateTo)) {
-            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) .
-                '</span> <span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span>';
+            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) .  '</span> ' .
+                '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span>';
             if (!DateComparison::isCurrentYear($dateFrom)) {
                 $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';
             }

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -35,12 +35,21 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
         $dateTo = $offer->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         if (DateComparison::onSameDay($dateFrom, $dateTo)) {
-            $output = '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span>';
+            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) .
+                '</span> <span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span>';
+            if (!DateComparison::isCurrentYear($dateFrom)) {
+                $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';
+            }
         } else {
-            $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span> ' .
-                '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateFrom) . '</span> ' .
-                '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span> ' .
-                '<span class="cf-date">' . $this->formatter->formatAsShortDate($dateTo) . '</span>';
+            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) .
+                '</span> <span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span>' .
+                ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>' .
+                ' - ' .
+                '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateTo) .
+                '</span> <span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateTo) . '</span>';
+            if (!DateComparison::isCurrentYear($dateTo)) {
+                $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateTo) . '</span>';
+            }
         }
 
         $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -41,12 +41,12 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
                 $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';
             }
         } else {
-            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) .
-                '</span> <span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span>' .
-                ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>' .
+            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) . '</span> ' .
+                '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span> ' .
+                '<span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>' .
                 ' - ' .
-                '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateTo) .
-                '</span> <span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateTo) . '</span>';
+                '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateTo) . '</span> ' .
+                '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateTo) . '</span>';
             if (!DateComparison::isCurrentYear($dateTo)) {
                 $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateTo) . '</span>';
             }

--- a/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
+++ b/src/Multiple/ExtraSmallMultipleHTMLFormatter.php
@@ -35,7 +35,7 @@ final class ExtraSmallMultipleHTMLFormatter implements MultipleFormatterInterfac
         $dateTo = $offer->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         if (DateComparison::onSameDay($dateFrom, $dateTo)) {
-            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) .  '</span> ' .
+            $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($dateFrom) . '</span> ' .
                 '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom) . '</span>';
             if (!DateComparison::isCurrentYear($dateFrom)) {
                 $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';

--- a/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/ExtraSmallMultiplePlainTextFormatter.php
@@ -35,15 +35,31 @@ final class ExtraSmallMultiplePlainTextFormatter implements MultipleFormatterInt
         $endDate = $offer->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         if (DateComparison::onSameDay($startDate, $endDate)) {
-            return PlainTextSummaryBuilder::start($this->translator)
-                ->append($this->formatter->formatAsShortDate($startDate))
-                ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
+            $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
+                ->append($this->formatter->formatAsDayNumber($startDate))
+                ->append($this->formatter->formatAsAbbreviatedMonthName($startDate));
+            if (!DateComparison::isCurrentYear($startDate)) {
+                $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($startDate));
+            }
+
+            return $plainTextSummaryBuilder->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
                 ->toString();
         }
 
-        return PlainTextSummaryBuilder::start($this->translator)
-            ->from($this->formatter->formatAsShortDate($startDate))
-            ->till($this->formatter->formatAsShortDate($endDate))
+        $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
+            ->append($this->formatter->formatAsDayNumber($startDate))
+            ->append($this->formatter->formatAsAbbreviatedMonthName($startDate));
+        if (!DateComparison::isCurrentYear($startDate)) {
+            $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($startDate));
+        }
+        $plainTextSummaryBuilder = $plainTextSummaryBuilder->append('-')
+            ->append($this->formatter->formatAsDayNumber($endDate))
+            ->append($this->formatter->formatAsAbbreviatedMonthName($endDate));
+        if (!DateComparison::isCurrentYear($endDate)) {
+            $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($endDate));
+        }
+
+        return $plainTextSummaryBuilder
             ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -65,8 +65,10 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
     private function formatSameDay(DateTimeInterface $dateFrom, string $intlDateFrom): string
     {
         $relativeDate = $this->getRelativeDate($dateFrom, $this->translator, $this->formatter);
-        return $relativeDate ?? ('<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>'
-                . ' '
-                . '<span class="cf-date">' . $intlDateFrom . '</span>');
+        return $relativeDate ?? (
+            '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>'
+            . ' '
+            . '<span class="cf-date">' . $intlDateFrom . '</span>'
+        );
     }
 }

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -34,18 +34,10 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
     public function format(Offer $offer): string
     {
         $dateFrom = $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-        $intlDateFrom = $this->formatter->formatAsDayNumber($dateFrom) .
-            ' ' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom);
-        if (!DateComparison::isCurrentYear($dateFrom)) {
-            $intlDateFrom .= ' ' . $this->formatter->formatAsYear($dateFrom);
-        }
+        $intlDateFrom = $this->getIntlDate($dateFrom);
 
         $dateTo = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-        $intlDateTo = $this->formatter->formatAsDayNumber($dateTo) .
-            ' ' . $this->formatter->formatAsAbbreviatedMonthName($dateTo);
-        if (!DateComparison::isCurrentYear($dateTo)) {
-            $intlDateTo .= ' ' . $this->formatter->formatAsYear($dateTo);
-        }
+        $intlDateTo = $this->getIntlDate($dateTo);
 
         if (DateComparison::onSameDay($dateFrom, $dateTo)) {
             $output = $this->formatSameDay($dateFrom, $intlDateFrom);
@@ -70,5 +62,15 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
             ' ' .
             '<span class="cf-date">' . $intlDateFrom . '</span>'
         );
+    }
+
+    private function getIntlDate(\DateTimeImmutable $dateTime): string
+    {
+        $intlDate = $this->formatter->formatAsDayNumber($dateTime) .
+            ' ' . $this->formatter->formatAsAbbreviatedMonthName($dateTime);
+        if (!DateComparison::isCurrentYear($dateTime)) {
+            $intlDate .= ' ' . $this->formatter->formatAsYear($dateTime);
+        }
+        return $intlDate;
     }
 }

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -66,9 +66,9 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
     {
         $relativeDate = $this->getRelativeDate($dateFrom, $this->translator, $this->formatter);
         return $relativeDate ?? (
-            '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>'
-            . ' '
-            . '<span class="cf-date">' . $intlDateFrom . '</span>'
+            '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>' .
+            ' ' .
+            '<span class="cf-date">' . $intlDateFrom . '</span>'
         );
     }
 }

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\DateComparison;
+use CultuurNet\CalendarSummaryV3\DateFormatter;
+use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
-use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
+use DateTimeInterface;
 
 final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
 {
+    /**
+     * @var DateFormatter
+     */
+    private $formatter;
+
     /**
      * @var Translator
      */
@@ -17,12 +25,64 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
 
     public function __construct(Translator $translator)
     {
+        $this->formatter = new DateFormatter($translator->getLocale());
         $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
     {
-        $formatter = new MediumPeriodicHTMLFormatter($this->translator);
-        return $formatter->format($offer);
+        $dateFrom = $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        $intlDateFrom = $this->formatter->formatAsDayNumber($dateFrom) .
+            ' ' . $this->formatter->formatAsAbbreviatedMonthName($dateFrom);
+        if (!DateComparison::isCurrentYear($dateFrom)) {
+            $intlDateFrom .= ' ' . $this->formatter->formatAsYear($dateFrom);
+        }
+
+        $dateTo = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        $intlDateTo = $this->formatter->formatAsDayNumber($dateTo) .
+            ' ' . $this->formatter->formatAsAbbreviatedMonthName($dateTo);
+        if (!DateComparison::isCurrentYear($dateTo)) {
+            $intlDateTo .= ' ' . $this->formatter->formatAsYear($dateTo);
+        }
+
+        if (DateComparison::onSameDay($dateFrom, $dateTo)) {
+            $output = $this->formatSameDay($dateFrom, $intlDateFrom);
+        } else {
+            $output = '<span class="cf-date">' . $intlDateFrom . '</span> '
+                . '<span class="cf-to cf-meta">-</span> ' .
+                '<span class="cf-date">' . $intlDateTo . '</span>';
+        }
+
+        $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)
+            ->withBraces()
+            ->toString();
+
+        return trim($output . ' ' . $optionalAvailability);
+    }
+
+    private function formatSameDay(DateTimeInterface $dateFrom, string $intlDateFrom): string
+    {
+        if (DateComparison::isThisEvening($dateFrom)) {
+            return '<span class="cf-days">' . $this->translator->translate('tonight') . '</span>';
+        }
+        if (DateComparison::isToday($dateFrom)) {
+            return '<span class="cf-days">' . $this->translator->translate('today') . '</span>';
+        }
+        if (DateComparison::isTomorrow($dateFrom)) {
+            return '<span class="cf-days">' . $this->translator->translate('tomorrow') . '</span>';
+        }
+        if (DateComparison::isCurrentWeek($dateFrom)) {
+            return '<span class="cf-meta">' .
+                $this->translator->translate('this') .
+                '</span>' .
+                ' ' .
+                '<span class="cf-days">' .
+                $this->formatter->formatAsDayOfWeek($dateFrom) .
+                '</span>';
+        }
+
+        return '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsDayOfWeek($dateFrom)) . '</span>'
+            . ' '
+            . '<span class="cf-date">' . $intlDateFrom . '</span>';
     }
 }

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -8,11 +8,13 @@ use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
+use CultuurNet\CalendarSummaryV3\RelativeDateHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use DateTimeInterface;
 
 final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
 {
+    use RelativeDateHTMLFormatter;
     /**
      * @var DateFormatter
      */
@@ -62,27 +64,9 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
 
     private function formatSameDay(DateTimeInterface $dateFrom, string $intlDateFrom): string
     {
-        if (DateComparison::isThisEvening($dateFrom)) {
-            return '<span class="cf-days">' . $this->translator->translate('tonight') . '</span>';
-        }
-        if (DateComparison::isToday($dateFrom)) {
-            return '<span class="cf-days">' . $this->translator->translate('today') . '</span>';
-        }
-        if (DateComparison::isTomorrow($dateFrom)) {
-            return '<span class="cf-days">' . $this->translator->translate('tomorrow') . '</span>';
-        }
-        if (DateComparison::isCurrentWeek($dateFrom)) {
-            return '<span class="cf-meta">' .
-                $this->translator->translate('this') .
-                '</span>' .
-                ' ' .
-                '<span class="cf-days">' .
-                $this->formatter->formatAsDayOfWeek($dateFrom) .
-                '</span>';
-        }
-
-        return '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>'
-            . ' '
-            . '<span class="cf-date">' . $intlDateFrom . '</span>';
+        $relativeDate = $this->getRelativeDate($dateFrom, $this->translator, $this->formatter);
+        return $relativeDate ?? ('<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>'
+                . ' '
+                . '<span class="cf-date">' . $intlDateFrom . '</span>');
     }
 }

--- a/src/Multiple/SmallMultipleHTMLFormatter.php
+++ b/src/Multiple/SmallMultipleHTMLFormatter.php
@@ -81,7 +81,7 @@ final class SmallMultipleHTMLFormatter implements MultipleFormatterInterface
                 '</span>';
         }
 
-        return '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsDayOfWeek($dateFrom)) . '</span>'
+        return '<span class="cf-weekday cf-meta">' . ucfirst($this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom)) . '</span>'
             . ' '
             . '<span class="cf-date">' . $intlDateFrom . '</span>';
     }

--- a/src/Multiple/SmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/SmallMultiplePlainTextFormatter.php
@@ -38,7 +38,7 @@ final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterfac
 
         if (DateComparison::onSameDay($startDate, $endDate)) {
             $relativeDate = $this->getRelativeDate($startDate, $this->translator, $this->formatter);
-            if (isset($relativeDate)) {
+            if ($relativeDate !== null) {
                 return $relativeDate;
             }
 

--- a/src/Multiple/SmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/SmallMultiplePlainTextFormatter.php
@@ -8,11 +8,13 @@ use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\PlainTextSummaryBuilder;
+use CultuurNet\CalendarSummaryV3\RelativeDatePlainTextFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use DateTimeZone;
 
 final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
+    use RelativeDatePlainTextFormatter;
     /**
      * @var DateFormatter
      */
@@ -35,20 +37,11 @@ final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterfac
         $endDate = $offer->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         if (DateComparison::onSameDay($startDate, $endDate)) {
-            if (DateComparison::isThisEvening($startDate)) {
-                return $this->translator->translate('tonight');
+            $relativeDate = $this->getRelativeDate($startDate, $this->translator, $this->formatter);
+            if (isset($relativeDate)) {
+                return $relativeDate;
             }
-            if (DateComparison::isToday($startDate)) {
-                return $this->translator->translate('today');
-            }
-            if (DateComparison::isTomorrow($startDate)) {
-                return $this->translator->translate('tomorrow');
-            }
-            if (DateComparison::isCurrentWeek($startDate)) {
-                $preposition = $this->translator->translate('this');
-                $weekDay = $this->formatter->formatAsDayOfWeek($startDate);
-                return PlainTextSummaryBuilder::singleLine($preposition, $weekDay);
-            }
+
             $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
                 ->append($this->formatter->formatAsAbbreviatedDayOfWeek($startDate))
                 ->append($this->formatter->formatAsDayNumber($startDate))

--- a/src/Multiple/SmallMultiplePlainTextFormatter.php
+++ b/src/Multiple/SmallMultiplePlainTextFormatter.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use CultuurNet\CalendarSummaryV3\DateComparison;
+use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
-use CultuurNet\CalendarSummaryV3\Periodic\MediumPeriodicPlainTextFormatter;
+use CultuurNet\CalendarSummaryV3\PlainTextSummaryBuilder;
 use CultuurNet\CalendarSummaryV3\Translator;
+use DateTimeZone;
 
 final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterface
 {
+    /**
+     * @var DateFormatter
+     */
+    private $formatter;
+
     /**
      * @var Translator
      */
@@ -17,12 +25,57 @@ final class SmallMultiplePlainTextFormatter implements MultipleFormatterInterfac
 
     public function __construct(Translator $translator)
     {
+        $this->formatter = new DateFormatter($translator->getLocale());
         $this->translator = $translator;
     }
 
     public function format(Offer $offer): string
     {
-        $formatter = new MediumPeriodicPlainTextFormatter($this->translator);
-        return $formatter->format($offer);
+        $startDate = $offer->getStartDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
+        $endDate = $offer->getEndDate()->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+        if (DateComparison::onSameDay($startDate, $endDate)) {
+            if (DateComparison::isThisEvening($startDate)) {
+                return $this->translator->translate('tonight');
+            }
+            if (DateComparison::isToday($startDate)) {
+                return $this->translator->translate('today');
+            }
+            if (DateComparison::isTomorrow($startDate)) {
+                return $this->translator->translate('tomorrow');
+            }
+            if (DateComparison::isCurrentWeek($startDate)) {
+                $preposition = $this->translator->translate('this');
+                $weekDay = $this->formatter->formatAsDayOfWeek($startDate);
+                return PlainTextSummaryBuilder::singleLine($preposition, $weekDay);
+            }
+            $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
+                ->append($this->formatter->formatAsAbbreviatedDayOfWeek($startDate))
+                ->append($this->formatter->formatAsDayNumber($startDate))
+                ->append($this->formatter->formatAsAbbreviatedMonthName($startDate));
+            if (!DateComparison::isCurrentYear($startDate)) {
+                $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($startDate));
+            }
+
+            return $plainTextSummaryBuilder->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
+                ->toString();
+        }
+
+        $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
+            ->append($this->formatter->formatAsDayNumber($startDate))
+            ->append($this->formatter->formatAsAbbreviatedMonthName($startDate));
+        if (!DateComparison::isCurrentYear($startDate)) {
+            $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($startDate));
+        }
+        $plainTextSummaryBuilder = $plainTextSummaryBuilder->append('-')
+            ->append($this->formatter->formatAsDayNumber($endDate))
+            ->append($this->formatter->formatAsAbbreviatedMonthName($endDate));
+        if (!DateComparison::isCurrentYear($endDate)) {
+            $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($endDate));
+        }
+
+        return $plainTextSummaryBuilder
+            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
+            ->toString();
     }
 }

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -41,10 +41,10 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
                 . ' '
                 . '<span class="cf-date">' . $intlDateFrom . '</span>';
         } else {
-            $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from'))
-                . '</span> <span class="cf-date">' . $intlDateFrom . '</span> '
-                . '<span class="cf-to cf-meta">' . $this->translator->translate('till')
-                . '</span> <span class="cf-date">' . $intlDateTo . '</span>';
+            $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span> '
+                . '<span class="cf-date">' . $intlDateFrom . '</span> '
+                . '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span> '
+                . '<span class="cf-date">' . $intlDateTo . '</span>';
         }
 
         $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)

--- a/src/RelativeDateHTMLFormatter.php
+++ b/src/RelativeDateHTMLFormatter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3;
+
+use DateTimeInterface;
+
+trait RelativeDateHTMLFormatter
+{
+    public function getRelativeDate(DateTimeInterface $date, Translator $translator, DateFormatter $formatter): ?string
+    {
+        if (DateComparison::isThisEvening($date)) {
+            return '<span class="cf-days">' . $translator->translate('tonight') . '</span>';
+        }
+        if (DateComparison::isToday($date)) {
+            return '<span class="cf-days">' . $translator->translate('today') . '</span>';
+        }
+        if (DateComparison::isTomorrow($date)) {
+            return '<span class="cf-days">' . $translator->translate('tomorrow') . '</span>';
+        }
+        if (DateComparison::isCurrentWeek($date)) {
+            return '<span class="cf-meta">' .
+                $translator->translate('this') .
+                '</span>' .
+                ' ' .
+                '<span class="cf-days">' .
+                $formatter->formatAsDayOfWeek($date) .
+                '</span>';
+        }
+        return null;
+    }
+}

--- a/src/RelativeDateHTMLFormatter.php
+++ b/src/RelativeDateHTMLFormatter.php
@@ -20,13 +20,9 @@ trait RelativeDateHTMLFormatter
             return '<span class="cf-days">' . $translator->translate('tomorrow') . '</span>';
         }
         if (DateComparison::isCurrentWeek($date)) {
-            return '<span class="cf-meta">' .
-                $translator->translate('this') .
-                '</span>' .
+            return '<span class="cf-meta">' . $translator->translate('this') . '</span>' .
                 ' ' .
-                '<span class="cf-days">' .
-                $formatter->formatAsDayOfWeek($date) .
-                '</span>';
+                '<span class="cf-days">' . $formatter->formatAsDayOfWeek($date) . '</span>';
         }
         return null;
     }

--- a/src/RelativeDatePlainTextFormatter.php
+++ b/src/RelativeDatePlainTextFormatter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3;
+
+use DateTimeInterface;
+
+trait RelativeDatePlainTextFormatter
+{
+    public function getRelativeDate(DateTimeInterface $date, Translator $translator, DateFormatter $formatter): ?string
+    {
+        if (DateComparison::isThisEvening($date)) {
+            return $translator->translate('tonight');
+        }
+        if (DateComparison::isToday($date)) {
+            return $translator->translate('today');
+        }
+        if (DateComparison::isTomorrow($date)) {
+            return $translator->translate('tomorrow');
+        }
+        if (DateComparison::isCurrentWeek($date)) {
+            $preposition = $translator->translate('this');
+            $weekDay = $formatter->formatAsDayOfWeek($date);
+            return PlainTextSummaryBuilder::singleLine($preposition, $weekDay);
+        }
+        return null;
+    }
+}

--- a/src/Single/MediumSingleHTMLFormatter.php
+++ b/src/Single/MediumSingleHTMLFormatter.php
@@ -50,7 +50,7 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
     private function formatSameDay(DateTimeInterface $dateFrom): string
     {
         $intlDateFrom = $this->formatter->formatAsFullDate($dateFrom);
-        $intlDateDayFrom = $this->formatter->formatAsDayOfWeek($dateFrom);
+        $intlDateDayFrom = $this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom);
 
         $output = '<span class="cf-weekday cf-meta">' . ucfirst($intlDateDayFrom) . '</span>';
         $output .= ' ';
@@ -62,10 +62,10 @@ final class MediumSingleHTMLFormatter implements SingleFormatterInterface
     private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
         $intlDateFrom = $this->formatter->formatAsFullDate($dateFrom);
-        $intlDateDayFrom = $this->formatter->formatAsDayOfWeek($dateFrom);
+        $intlDateDayFrom = $this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom);
 
         $intlDateEnd = $this->formatter->formatAsFullDate($dateEnd);
-        $intlDateDayEnd = $this->formatter->formatAsDayOfWeek($dateEnd);
+        $intlDateDayEnd = $this->formatter->formatAsAbbreviatedDayOfWeek($dateEnd);
 
         $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span>';
         $output .= ' ';

--- a/src/Single/MediumSinglePlainTextFormatter.php
+++ b/src/Single/MediumSinglePlainTextFormatter.php
@@ -56,10 +56,10 @@ final class MediumSinglePlainTextFormatter implements SingleFormatterInterface
     private function formatMoreDays(DateTimeInterface $startDate, DateTimeInterface $endDate): string
     {
         $formattedStartDate = $this->formatter->formatAsFullDate($startDate);
-        $formattedStartDayOfWeek = $this->formatter->formatAsDayOfWeek($startDate);
+        $formattedStartDayOfWeek = $this->formatter->formatAsAbbreviatedDayOfWeek($startDate);
 
         $formattedEndDate = $this->formatter->formatAsFullDate($endDate);
-        $formattedEndDayOfWeek = $this->formatter->formatAsDayOfWeek($endDate);
+        $formattedEndDayOfWeek = $this->formatter->formatAsAbbreviatedDayOfWeek($endDate);
 
         return PlainTextSummaryBuilder::start($this->translator)
             ->from($formattedStartDayOfWeek, $formattedStartDate)

--- a/src/Single/SmallSingleHTMLFormatter.php
+++ b/src/Single/SmallSingleHTMLFormatter.php
@@ -7,12 +7,14 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\HtmlAvailabilityFormatter;
+use CultuurNet\CalendarSummaryV3\RelativeDateHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
 
 final class SmallSingleHTMLFormatter implements SingleFormatterInterface
 {
+    use RelativeDateHTMLFormatter;
     /**
      * @var DateFormatter
      */
@@ -49,23 +51,9 @@ final class SmallSingleHTMLFormatter implements SingleFormatterInterface
 
     private function formatSameDay(DateTimeInterface $dateFrom): string
     {
-        if (DateComparison::isThisEvening($dateFrom)) {
-            return '<span class="cf-days">' . $this->translator->translate('tonight') . '</span>';
-        }
-        if (DateComparison::isToday($dateFrom)) {
-            return '<span class="cf-days">' . $this->translator->translate('today') . '</span>';
-        }
-        if (DateComparison::isTomorrow($dateFrom)) {
-            return '<span class="cf-days">' . $this->translator->translate('tomorrow') . '</span>';
-        }
-        if (DateComparison::isCurrentWeek($dateFrom)) {
-            return '<span class="cf-meta">' .
-                $this->translator->translate('this') .
-                '</span>' .
-                ' ' .
-                '<span class="cf-days">' .
-                $this->formatter->formatAsDayOfWeek($dateFrom) .
-                '</span>';
+        $relativeDate = $this->getRelativeDate($dateFrom, $this->translator, $this->formatter);
+        if (isset($relativeDate)) {
+            return $relativeDate;
         }
 
         $dateFromDay = $this->formatter->formatAsDayNumber($dateFrom);

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -51,7 +51,7 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
     private function formatSameDay(DateTimeInterface $date): string
     {
         $relativeDate = $this->getRelativeDate($date, $this->translator, $this->formatter);
-        if (isset($relativeDate)) {
+        if ($relativeDate !== null) {
             return $relativeDate;
         }
 

--- a/src/Single/SmallSinglePlainTextFormatter.php
+++ b/src/Single/SmallSinglePlainTextFormatter.php
@@ -7,12 +7,14 @@ namespace CultuurNet\CalendarSummaryV3\Single;
 use CultuurNet\CalendarSummaryV3\DateComparison;
 use CultuurNet\CalendarSummaryV3\DateFormatter;
 use CultuurNet\CalendarSummaryV3\PlainTextSummaryBuilder;
+use CultuurNet\CalendarSummaryV3\RelativeDatePlainTextFormatter;
 use CultuurNet\CalendarSummaryV3\Translator;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use DateTimeInterface;
 
 final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
 {
+    use RelativeDatePlainTextFormatter;
     /**
      * @var DateFormatter
      */
@@ -48,20 +50,11 @@ final class SmallSinglePlainTextFormatter implements SingleFormatterInterface
 
     private function formatSameDay(DateTimeInterface $date): string
     {
-        if (DateComparison::isThisEvening($date)) {
-            return $this->translator->translate('tonight');
+        $relativeDate = $this->getRelativeDate($date, $this->translator, $this->formatter);
+        if (isset($relativeDate)) {
+            return $relativeDate;
         }
-        if (DateComparison::isToday($date)) {
-            return $this->translator->translate('today');
-        }
-        if (DateComparison::isTomorrow($date)) {
-            return $this->translator->translate('tomorrow');
-        }
-        if (DateComparison::isCurrentWeek($date)) {
-            $preposition = $this->translator->translate('this');
-            $weekDay = $this->formatter->formatAsDayOfWeek($date);
-            return PlainTextSummaryBuilder::singleLine($preposition, $weekDay);
-        }
+
         $dayNumber = $this->formatter->formatAsDayNumber($date);
         $monthName = $this->formatter->formatAsAbbreviatedMonthName($date);
         if (DateComparison::isCurrentYear($date)) {

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallMultipleHTMLFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void
@@ -166,8 +168,8 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable('08-10-' . (new DateTimeImmutable())->format('Y') . ' 12:00'),
-            new DateTimeImmutable('08-10-' . (new DateTimeImmutable())->format('Y') . ' 14:00'),
+            CarbonImmutable::create(2021, 10, 8)->setTime(12, 0),
+            CarbonImmutable::create(2021, 10, 8)->setTime(14, 0),
             CalendarType::multiple()
         );
 

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -37,8 +37,9 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25/11/25</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30/11/30</span>',
+            '<span class="cf-date">25</span> <span class="cf-month">nov</span> <span class="cf-year">2025</span>'
+            . ' - '
+            . '<span class="cf-date">30</span> <span class="cf-month">nov</span> <span class="cf-year">2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -55,8 +56,9 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">4/3/25</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">8/3/30</span>',
+            '<span class="cf-date">4</span> <span class="cf-month">mrt</span> <span class="cf-year">2025</span>'
+            . ' - '
+            . '<span class="cf-date">8</span> <span class="cf-month">mrt</span> <span class="cf-year">2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -73,8 +75,9 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25/11/25</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30/11/30</span>'
+            '<span class="cf-date">25</span> <span class="cf-month">nov</span> <span class="cf-year">2025</span>'
+            . ' - '
+            . '<span class="cf-date">30</span> <span class="cf-month">nov</span> <span class="cf-year">2030</span>'
             . ' <span class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($offer)
         );
@@ -92,8 +95,9 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25/11/25</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30/11/30</span>'
+            '<span class="cf-date">25</span> <span class="cf-month">nov</span> <span class="cf-year">2025</span>'
+            . ' - '
+            . '<span class="cf-date">30</span> <span class="cf-month">nov</span> <span class="cf-year">2030</span>'
             . ' <span class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($offer)
         );
@@ -111,8 +115,9 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25/11/25</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30/11/30</span>'
+            '<span class="cf-date">25</span> <span class="cf-month">nov</span> <span class="cf-year">2025</span>'
+            . ' - '
+            . '<span class="cf-date">30</span> <span class="cf-month">nov</span> <span class="cf-year">2030</span>'
             . ' <span class="cf-status">(Volzet of uitverkocht)</span>',
             $this->formatter->format($offer)
         );
@@ -130,8 +135,8 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">4/10/25</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">8/10/30</span>',
+            '<span class="cf-date">4</span> <span class="cf-month">okt</span> <span class="cf-year">2025</span>' .
+            ' - <span class="cf-date">8</span> <span class="cf-month">okt</span> <span class="cf-year">2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -147,7 +152,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
             CalendarType::multiple()
         );
 
-        $output = '<span class="cf-date">8/10/25</span>';
+        $output = '<span class="cf-date">8</span> <span class="cf-month">okt</span> <span class="cf-year">2025</span>';
 
         $this->assertEquals(
             $output,

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -159,4 +159,23 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
             $this->formatter->format($offer)
         );
     }
+
+    public function testFormatAMultipleWithSameBeginAndEndDayCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('08-10-' . (new DateTimeImmutable())->format('Y') . ' 12:00'),
+            new DateTimeImmutable('08-10-' . (new DateTimeImmutable())->format('Y') . ' 14:00'),
+            CalendarType::multiple()
+        );
+
+        $output = '<span class="cf-date">8</span> <span class="cf-month">okt</span>';
+
+        $this->assertEquals(
+            $output,
+            $this->formatter->format($offer)
+        );
+    }
 }

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -180,6 +180,23 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatAPeriodWithSameBeginAndEndDateCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 3, 8)->setTime(11, 0),
+            CarbonImmutable::create(2021, 3, 8)->setTime(19, 0),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '8 mrt',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatMultipleMonthWithUnavailableStatus(): void
     {
         $offer = new Offer(

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -37,7 +37,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25/11/25 tot 30/11/30',
+            '25 nov 2025 - 30 nov 2030',
             $this->formatter->format($offer)
         );
     }
@@ -54,7 +54,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4/3/25 tot 8/3/30',
+            '4 mrt 2025 - 8 mrt 2030',
             $this->formatter->format($offer)
         );
     }
@@ -71,7 +71,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25/11/25 tot 30/11/30 (geannuleerd)',
+            '25 nov 2025 - 30 nov 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -88,7 +88,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '30/11/30 (geannuleerd)',
+            '30 nov 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -105,7 +105,41 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25/3/25 tot 30/3/30',
+            '25 mrt 2025 - 30 mrt 2030',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleDayStartCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-03-' . (new DateTimeImmutable())->format('Y')),
+            new DateTimeImmutable('30-03-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '25 mrt - 30 mrt 2030',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleDayEndCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-03-2020'),
+            new DateTimeImmutable('30-03-' . (new DateTimeImmutable())->format('Y')),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '25 mrt 2020 - 30 mrt',
             $this->formatter->format($offer)
         );
     }
@@ -122,7 +156,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4/10/25 tot 8/10/30',
+            '4 okt 2025 - 8 okt 2030',
             $this->formatter->format($offer)
         );
     }
@@ -139,7 +173,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '8/3/25',
+            '8 mrt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -156,7 +190,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4/10/25 tot 8/10/30 (geannuleerd)',
+            '4 okt 2025 - 8 okt 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -173,7 +207,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4/10/25 tot 8/10/30 (geannuleerd)',
+            '4 okt 2025 - 8 okt 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -190,7 +224,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4/10/25 tot 8/10/30 (Volzet of uitverkocht)',
+            '4 okt 2025 - 8 okt 2030 (Volzet of uitverkocht)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallMultiplePlainTextFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void
@@ -116,8 +118,8 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable('25-03-' . (new DateTimeImmutable())->format('Y')),
-            new DateTimeImmutable('30-03-2030'),
+            CarbonImmutable::create(2021, 3, 25),
+            CarbonImmutable::create(2030, 3, 30),
             CalendarType::multiple()
         );
 
@@ -133,8 +135,8 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable('25-03-2020'),
-            new DateTimeImmutable('30-03-' . (new DateTimeImmutable())->format('Y')),
+            CarbonImmutable::create(2020, 03, 25),
+            CarbonImmutable::create(2021, 3, 30),
             CalendarType::multiple()
         );
 

--- a/tests/Multiple/MediumMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/MediumMultipleHTMLFormatterTest.php
@@ -51,13 +51,13 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $event = $event->withSubEvents($newEvents);
 
         $expectedOutput = '<ul class="cnw-event-date-info"><li>';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">9 november 2017</span></li>';
-        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">16 november 2017</span></li>';
-        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">23 november 2017</span></li>';
-        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">30 november 2017</span></li></ul>';
 
         $this->assertEquals(
@@ -99,13 +99,13 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
         $event = $event->withSubEvents($newEvents);
 
         $expectedOutput = '<ul class="cnw-event-date-info"><li>';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">9 november 2017</span></li>';
-        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">16 november 2017</span> <span class="cf-status">(geannuleerd)</span></li>';
-        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">23 november 2017</span> <span class="cf-status">(Volzet of uitverkocht)</span></li>';
-        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Donderdag</span> ';
+        $expectedOutput .= '<li><span class="cf-weekday cf-meta">Do</span> ';
         $expectedOutput .= '<span class="cf-date">30 november 2017</span></li></ul>';
 
         $this->assertEquals(
@@ -141,28 +141,28 @@ final class MediumMultipleHTMLFormatterTest extends TestCase
 
         $expectedOutput = '<ul class="cnw-event-date-info"><li>';
         $expectedOutput .= '<span class="cf-from cf-meta">Van</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">maandag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">ma</span> ';
         $expectedOutput .= '<span class="cf-date">6 november 2017</span> ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">donderdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">do</span> ';
         $expectedOutput .= '<span class="cf-date">9 november 2017</span></li>';
         $expectedOutput .= '<li><span class="cf-from cf-meta">Van</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">dinsdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">di</span> ';
         $expectedOutput .= '<span class="cf-date">14 november 2017</span> ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">donderdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">do</span> ';
         $expectedOutput .= '<span class="cf-date">16 november 2017</span></li>';
         $expectedOutput .= '<li><span class="cf-from cf-meta">Van</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">dinsdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">di</span> ';
         $expectedOutput .= '<span class="cf-date">21 november 2017</span> ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">donderdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">do</span> ';
         $expectedOutput .= '<span class="cf-date">23 november 2017</span></li>';
         $expectedOutput .= '<li><span class="cf-from cf-meta">Van</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">dinsdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">di</span> ';
         $expectedOutput .= '<span class="cf-date">28 november 2017</span> ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span> ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">donderdag</span> ';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">do</span> ';
         $expectedOutput .= '<span class="cf-date">30 november 2017</span></li></ul>';
 
         $this->assertEquals(

--- a/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/MediumMultiplePlainTextFormatterTest.php
@@ -86,10 +86,10 @@ final class MediumMultiplePlainTextFormatterTest extends TestCase
 
         $event = $event->withSubEvents($newEvents);
 
-        $expectedOutput = 'Van maandag 6 november 2017 tot donderdag 9 november 2017' . PHP_EOL;
-        $expectedOutput .= 'Van dinsdag 14 november 2017 tot donderdag 16 november 2017' . PHP_EOL;
-        $expectedOutput .= 'Van dinsdag 21 november 2017 tot donderdag 23 november 2017' . PHP_EOL;
-        $expectedOutput .= 'Van dinsdag 28 november 2017 tot donderdag 30 november 2017';
+        $expectedOutput = 'Van ma 6 november 2017 tot do 9 november 2017' . PHP_EOL;
+        $expectedOutput .= 'Van di 14 november 2017 tot do 16 november 2017' . PHP_EOL;
+        $expectedOutput .= 'Van di 21 november 2017 tot do 23 november 2017' . PHP_EOL;
+        $expectedOutput .= 'Van di 28 november 2017 tot do 30 november 2017';
 
         $this->assertEquals(
             $expectedOutput,

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -113,6 +113,60 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 11, 25),
+            CarbonImmutable::create(2021, 11, 30),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-date">25 nov</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">30 nov</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleStartsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 11, 25),
+            CarbonImmutable::create(2030, 11, 30),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-date">25 nov</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">30 nov 2030</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleEndsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2020'),
+            new DateTimeImmutable('30-11-2021'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-date">25 nov 2020</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">30 nov</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatMultipleWithoutLeadingZeroesWithUnavailableStatus(): void
     {
         $offer = new Offer(

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -90,7 +90,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-days">Deze</span> <span class="cf-days">vrijdag</span>',
+            '<span class="cf-meta">Deze</span> <span class="cf-days">vrijdag</span>',
             $this->formatter->format($offer)
         );
     }
@@ -198,7 +198,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
             CalendarType::multiple()
         );
 
-        $output = '<span class="cf-weekday cf-meta">Woensdag</span>';
+        $output = '<span class="cf-weekday cf-meta">Wo</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">8 okt 2025</span>';
 

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,24 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallMultipleHTMLFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+    }
+
+    public function testFormatMultipleOnSamedayToday(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 5, 3)->setTime(11, 30),
+            CarbonImmutable::create(2021, 5, 3)->setTime(20, 30),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-days">Vandaag</span>',
+            $this->formatter->format($offer)
+        );
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void
@@ -37,8 +56,8 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 november 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 november 2030</span>',
+            '<span class="cf-date">25 nov 2025</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">30 nov 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -55,8 +74,8 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 november 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 november 2030</span>'
+            '<span class="cf-date">25 nov 2025</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">30 nov 2030</span>'
             . ' <span class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($offer)
         );
@@ -74,8 +93,8 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 november 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 november 2030</span>'
+            '<span class="cf-date">25 nov 2025</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">30 nov 2030</span>'
             . ' <span class="cf-status">(Volzet of uitverkocht)</span>',
             $this->formatter->format($offer)
         );
@@ -93,8 +112,8 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">4 maart 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">8 maart 2030</span>',
+            '<span class="cf-date">4 mrt 2025</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">8 mrt 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -111,8 +130,8 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">4 oktober 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">8 oktober 2030</span>',
+            '<span class="cf-date">4 okt 2025</span> '
+            . '<span class="cf-to cf-meta">-</span> <span class="cf-date">8 okt 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -130,7 +149,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
 
         $output = '<span class="cf-weekday cf-meta">Woensdag</span>';
         $output .= ' ';
-        $output .= '<span class="cf-date">8 oktober 2025</span>';
+        $output .= '<span class="cf-date">8 okt 2025</span>';
 
         $this->assertEquals(
             $output,

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -44,6 +44,57 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleOnSamedayTonight(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 5, 3)->setTime(18, 30),
+            CarbonImmutable::create(2021, 5, 3)->setTime(20, 30),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-days">Vanavond</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleOnSamedayTomorrow(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 5, 4)->setTime(11, 30),
+            CarbonImmutable::create(2021, 5, 4)->setTime(20, 30),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-days">Morgen</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleOnSamedayThisWeek(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 5, 7)->setTime(11, 30),
+            CarbonImmutable::create(2021, 5, 7)->setTime(20, 30),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '<span class="cf-days">Deze</span> <span class="cf-days">vrijdag</span>',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatMultipleWithoutLeadingZeroes(): void
     {
         $offer = new Offer(

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
 use CultuurNet\CalendarSummaryV3\Translator;
-use DateInterval;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
@@ -24,6 +24,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallMultiplePlainTextFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void
@@ -49,8 +50,8 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T11:00:00+01:00'),
-            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T15:00:00+01:00'),
+            CarbonImmutable::create(2021, 5, 3)->setTime(11, 30),
+            CarbonImmutable::create(2021, 5, 3)->setTime(20, 30),
             CalendarType::multiple()
         );
 
@@ -66,8 +67,8 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T18:00:00+01:00'),
-            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T21:00:00+01:00'),
+            CarbonImmutable::create(2021, 5, 3)->setTime(18, 0),
+            CarbonImmutable::create(2021, 5, 3)->setTime(21, 30),
             CalendarType::multiple()
         );
 
@@ -79,13 +80,12 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
 
     public function testFormatMultipleSingleDateSmTomorrow(): void
     {
-        $tomorrow = (new DateTimeImmutable())->add(new DateInterval('P1D'));
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable($tomorrow->format('Y-m-d') . 'T18:30:00+01:00'),
-            new DateTimeImmutable($tomorrow->format('Y-m-d') . 'T22:30:00+01:00'),
+            CarbonImmutable::create(2021, 5, 4)->setTime(18, 0),
+            CarbonImmutable::create(2021, 5, 4)->setTime(21, 30),
             CalendarType::multiple()
         );
 
@@ -97,15 +97,12 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
 
     public function testFormatMultipleCurrentWeek(): void
     {
-        $offSet = (int) (new DateTimeImmutable())->format('w');
-        $daysTillSunday = 7 - $offSet;
-        $thisSunday = (new DateTimeImmutable())->add(new DateInterval('P' . $daysTillSunday . 'D'));
         $event = new Offer(
             OfferType::event(),
             new Status('Available', []),
             new BookingAvailability('Available'),
-            new DateTimeImmutable($thisSunday->format('Y-m-d') . 'T18:30:00+01:00'),
-            new DateTimeImmutable($thisSunday->format('Y-m-d') . 'T22:30:00+01:00'),
+            CarbonImmutable::create(2021, 5, 9)->setTime(18, 0),
+            CarbonImmutable::create(2021, 5, 9)->setTime(21, 30),
             CalendarType::multiple()
         );
 

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -129,6 +129,57 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatMultipleCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('04-03-2021'),
+            new DateTimeImmutable('08-03-2021'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '4 mrt - 8 mrt',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleStartsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('04-03-2021'),
+            new DateTimeImmutable('08-03-2030'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '4 mrt - 8 mrt 2030',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleEndsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('04-03-2020'),
+            new DateTimeImmutable('08-03-2021'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            '4 mrt 2020 - 8 mrt',
+            $this->formatter->format($offer)
+        );
+    }
+
     public function testFormatMultipleWithUnavailableStatus(): void
     {
         $offer = new Offer(

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -10,6 +10,7 @@ use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
 use CultuurNet\CalendarSummaryV3\Offer\Status;
 use CultuurNet\CalendarSummaryV3\Translator;
+use DateInterval;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
@@ -37,8 +38,80 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030',
+            '25 nov 2025 - 30 nov 2030',
             $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleOnSamedayToday(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T11:00:00+01:00'),
+            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T15:00:00+01:00'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            'Vandaag',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleOnSamedayTonight(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T18:00:00+01:00'),
+            new DateTimeImmutable((new DateTimeImmutable())->format('Y-m-d') . 'T21:00:00+01:00'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            'Vanavond',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatMultipleSingleDateSmTomorrow(): void
+    {
+        $tomorrow = (new DateTimeImmutable())->add(new DateInterval('P1D'));
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable($tomorrow->format('Y-m-d') . 'T18:30:00+01:00'),
+            new DateTimeImmutable($tomorrow->format('Y-m-d') . 'T22:30:00+01:00'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            'Morgen',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatMultipleCurrentWeek(): void
+    {
+        $offSet = (int) (new DateTimeImmutable())->format('w');
+        $daysTillSunday = 7 - $offSet;
+        $thisSunday = (new DateTimeImmutable())->add(new DateInterval('P' . $daysTillSunday . 'D'));
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable($thisSunday->format('Y-m-d') . 'T18:30:00+01:00'),
+            new DateTimeImmutable($thisSunday->format('Y-m-d') . 'T22:30:00+01:00'),
+            CalendarType::multiple()
+        );
+
+        $this->assertEquals(
+            'Deze zondag',
+            $this->formatter->format($event)
         );
     }
 
@@ -54,7 +127,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4 maart 2025 tot 8 maart 2030',
+            '4 mrt 2025 - 8 mrt 2030',
             $this->formatter->format($offer)
         );
     }
@@ -71,7 +144,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030 (geannuleerd)',
+            '25 nov 2025 - 30 nov 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -88,7 +161,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 maart 2025 tot 30 maart 2030',
+            '25 mrt 2025 - 30 mrt 2030',
             $this->formatter->format($offer)
         );
     }
@@ -105,7 +178,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4 oktober 2025 tot 8 oktober 2030',
+            '4 okt 2025 - 8 okt 2030',
             $this->formatter->format($offer)
         );
     }
@@ -122,7 +195,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 maart 2025 tot 30 maart 2030 (geannuleerd)',
+            '25 mrt 2025 - 30 mrt 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -139,7 +212,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Woensdag 8 oktober 2025',
+            'Wo 8 okt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -156,7 +229,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Woensdag 8 oktober 2025 (geannuleerd)',
+            'Wo 8 okt 2025 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Single/MediumSingleHTMLFormatterTest.php
+++ b/tests/Single/MediumSingleHTMLFormatterTest.php
@@ -35,7 +35,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-weekday cf-meta">Donderdag</span> <span class="cf-date">25 januari 2018</span>',
+            '<span class="cf-weekday cf-meta">Do</span> <span class="cf-date">25 januari 2018</span>',
             $this->formatter->format($event)
         );
     }
@@ -51,7 +51,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-weekday cf-meta">Donderdag</span> <span class="cf-date">25 januari 2018</span> <span class="cf-status">(geannuleerd)</span>',
+            '<span class="cf-weekday cf-meta">Do</span> <span class="cf-date">25 januari 2018</span> <span class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($event)
         );
     }
@@ -67,7 +67,7 @@ final class MediumSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-weekday cf-meta">Maandag</span> <span class="cf-date">8 januari 2018</span>',
+            '<span class="cf-weekday cf-meta">Ma</span> <span class="cf-date">8 januari 2018</span>',
             $this->formatter->format($event)
         );
     }
@@ -84,13 +84,13 @@ final class MediumSingleHTMLFormatterTest extends TestCase
 
         $expectedOutput = '<span class="cf-from cf-meta">Van</span>';
         $expectedOutput .= ' ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">donderdag</span>';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">do</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">25 januari 2018</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span>';
         $expectedOutput .= ' ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">zondag</span>';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">zo</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">28 januari 2018</span>';
 
@@ -112,13 +112,13 @@ final class MediumSingleHTMLFormatterTest extends TestCase
 
         $expectedOutput = '<span class="cf-from cf-meta">Van</span>';
         $expectedOutput .= ' ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">zaterdag</span>';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">za</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">6 januari 2018</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span>';
         $expectedOutput .= ' ';
-        $expectedOutput .= '<span class="cf-weekday cf-meta">maandag</span>';
+        $expectedOutput .= '<span class="cf-weekday cf-meta">ma</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">8 januari 2018</span>';
 

--- a/tests/Single/MediumSinglePlainTextFormatterTest.php
+++ b/tests/Single/MediumSinglePlainTextFormatterTest.php
@@ -67,7 +67,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van donderdag 25 januari 2018 tot zaterdag 27 januari 2018',
+            'Van do 25 januari 2018 tot za 27 januari 2018',
             $this->formatter->format($event)
         );
     }
@@ -83,7 +83,7 @@ final class MediumSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van zaterdag 6 januari 2018 tot maandag 8 januari 2018',
+            'Van za 6 januari 2018 tot ma 8 januari 2018',
             $this->formatter->format($event)
         );
     }


### PR DESCRIPTION
### Changed

- Added `RelativeDatePlainTextFormatter` & `RelativeDateHTMLFormatter` to avoid duplicate code

1.`xs` 
- omit the year if it is not the current year
- Summary consists of day of & abbreviated month 
- replace `from` & `till` with `-`

2.`sm`
- Use relative dates like relatively the event is "today", tonight", "tomorrow" or "later this week"
- Summary consists of day of & abbreviated month
- replace `from` & `till` with `-`

3.`md`
- Days are never written in full but abbreviated

---

Ticket: https://jira.uitdatabank.be/browse/III-4498
