### PR TITLE
III-4499 changes CalendarType Periodic

### DIFF
--- a/src/DateComparison.php
+++ b/src/DateComparison.php
@@ -52,7 +52,7 @@ final class DateComparison
     public static function inTheFuture(DateTimeImmutable $date): bool
     {
         $date = $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
-        $now = new DateTimeImmutable();
+        $now = new CarbonImmutable();
         return $date > $now;
     }
 }

--- a/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicHTMLFormatter.php
@@ -64,13 +64,11 @@ final class ExtraSmallPeriodicHTMLFormatter implements PeriodicFormatterInterfac
 
     private function formatDate(DateTimeInterface $date): string
     {
-        $dateFromDay = $this->formatter->formatAsDayNumber($date);
-        $dateFromMonth = $this->formatter->formatAsMonthNumber($date);
-        $dateFromYear = $this->formatter->formatAsShortYear($date);
-
-        return
-            '<span class="cf-date">' . $dateFromDay . '</span>/' .
-            '<span class="cf-month">' . $dateFromMonth . '</span>/' .
-            '<span class="cf-year">' . $dateFromYear . '</span>';
+        $formattedDate = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($date) . '</span>/' .
+            '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($date) . '</span>';
+        if (!DateComparison::isCurrentYear($date)) {
+            $formattedDate .= '/<span class="cf-year">' . $this->formatter->formatAsYear($date) . '</span>';
+        }
+        return $formattedDate;
     }
 }

--- a/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/ExtraSmallPeriodicPlainTextFormatter.php
@@ -34,16 +34,28 @@ final class ExtraSmallPeriodicPlainTextFormatter implements PeriodicFormatterInt
         $startDate->setTime(0, 0, 1);
 
         if (DateComparison::inTheFuture($startDate)) {
-            return PlainTextSummaryBuilder::start($this->translator)
-                ->fromPeriod($this->formatter->formatAsShortDate($startDate))
-                ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
+            $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
+                ->fromPeriod(
+                    $this->formatter->formatAsDayNumber($startDate),
+                    $this->formatter->formatAsAbbreviatedMonthName($startDate)
+                );
+            if (!DateComparison::isCurrentYear($startDate)) {
+                $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($startDate));
+            }
+            return $plainTextSummaryBuilder->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
                 ->toString();
         }
 
         $endDate = $offer->getEndDate();
-        return PlainTextSummaryBuilder::start($this->translator)
-            ->till($this->formatter->formatAsShortDate($endDate))
-            ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
+        $plainTextSummaryBuilder = PlainTextSummaryBuilder::start($this->translator)
+            ->till(
+                $this->formatter->formatAsDayNumber($endDate),
+                $this->formatter->formatAsAbbreviatedMonthName($endDate)
+            );
+        if (!DateComparison::isCurrentYear($endDate)) {
+            $plainTextSummaryBuilder = $plainTextSummaryBuilder->append($this->formatter->formatAsYear($endDate));
+        }
+        return $plainTextSummaryBuilder->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }
 }

--- a/src/Periodic/LargePeriodicHTMLFormatter.php
+++ b/src/Periodic/LargePeriodicHTMLFormatter.php
@@ -106,9 +106,11 @@ final class LargePeriodicHTMLFormatter implements PeriodicFormatterInterface
         $intlDateTo = $this->formatter->formatAsFullDate($dateTo);
 
         return '<p class="cf-period">'
+            . '<span class="cf-weekday cf-meta">' . $this->formatter->formatAsDayOfWeek($dateFrom) . '</span>'
             . '<time itemprop="startDate" datetime="' . $dateFrom->format('Y-m-d') . '">'
             . '<span class="cf-date">' . $intlDateFrom . '</span> </time>'
-            . '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>'
+            . '<span class="cf-to cf-meta">' . $this->translator->translate('to') . '</span>'
+            . '<span class="cf-weekday cf-meta">' . $this->formatter->formatAsDayOfWeek($dateTo) . '</span>'
             . '<time itemprop="endDate" datetime="' . $dateTo->format('Y-m-d') . '">'
             . '<span class="cf-date">' . $intlDateTo . '</span> </time>'
             . $optionalStatus

--- a/src/Periodic/LargePeriodicPlainTextFormatter.php
+++ b/src/Periodic/LargePeriodicPlainTextFormatter.php
@@ -36,11 +36,13 @@ final class LargePeriodicPlainTextFormatter implements PeriodicFormatterInterfac
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $formattedStartDate = $this->formatter->formatAsFullDate($startDate);
+        $formattedStartDayName = $this->formatter->formatAsDayOfWeek($startDate);
         $formattedEndDate = $this->formatter->formatAsFullDate($endDate);
+        $formattedEndDayName = $this->formatter->formatAsDayOfWeek($endDate);
 
         $summary = PlainTextSummaryBuilder::start($this->translator)
-            ->from($formattedStartDate)
-            ->till($formattedEndDate);
+            ->from($formattedStartDayName, $formattedStartDate)
+            ->to($formattedEndDayName, $formattedEndDate);
 
         if ($offer->getOpeningHours()) {
             $summary = $summary

--- a/src/Periodic/MediumPeriodicHTMLFormatter.php
+++ b/src/Periodic/MediumPeriodicHTMLFormatter.php
@@ -31,10 +31,11 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
     {
         $dateFrom = $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $intlDateFrom = $this->formatter->formatAsFullDate($dateFrom);
-        $intlDateFromDay = $this->formatter->formatAsDayOfWeek($dateFrom);
+        $intlDateFromDay = $this->formatter->formatAsAbbreviatedDayOfWeek($dateFrom);
 
         $dateTo = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $intlDateTo = $this->formatter->formatAsFullDate($dateTo);
+        $intlDateDayTo = $this->formatter->formatAsAbbreviatedDayOfWeek($dateTo);
 
         if ($intlDateFrom == $intlDateTo) {
             $output = '<span class="cf-weekday cf-meta">' . ucfirst($intlDateFromDay) . '</span>'
@@ -42,9 +43,11 @@ final class MediumPeriodicHTMLFormatter implements PeriodicFormatterInterface
                 . '<span class="cf-date">' . $intlDateFrom . '</span>';
         } else {
             $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from'))
-                . '</span> <span class="cf-date">' . $intlDateFrom . '</span> '
+                . '</span> <span class="cf-weekday cf-meta">' . $intlDateFromDay . '</span> '
+                . '<span class="cf-date">' . $intlDateFrom . '</span> '
                 . '<span class="cf-to cf-meta">' . $this->translator->translate('till')
-                . '</span> <span class="cf-date">' . $intlDateTo . '</span>';
+                . '</span> <span class="cf-weekday cf-meta">' . $intlDateDayTo . '</span> '
+                . '<span class="cf-date">' . $intlDateTo . '</span>';
         }
 
         $optionalAvailability = HtmlAvailabilityFormatter::forOffer($offer, $this->translator)

--- a/src/Periodic/MediumPeriodicPlainTextFormatter.php
+++ b/src/Periodic/MediumPeriodicPlainTextFormatter.php
@@ -31,10 +31,11 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
     {
         $startDate = $offer->getStartDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $formattedStartDate = $this->formatter->formatAsFullDate($startDate);
-        $formattedStartDayOfWeek = $this->formatter->formatAsDayOfWeek($startDate);
+        $formattedStartDayOfWeek = $this->formatter->formatAsAbbreviatedDayOfWeek($startDate);
 
         $endDate = $offer->getEndDate()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $formattedEndDate = $this->formatter->formatAsFullDate($endDate);
+        $formattedEndDayOfWeek = $this->formatter->formatAsAbbreviatedDayOfWeek($endDate);
 
         $summaryBuilder = PlainTextSummaryBuilder::start($this->translator);
 
@@ -46,8 +47,8 @@ final class MediumPeriodicPlainTextFormatter implements PeriodicFormatterInterfa
         }
 
         return $summaryBuilder
-            ->from($formattedStartDate)
-            ->till($formattedEndDate)
+            ->from($formattedStartDayOfWeek, $formattedStartDate)
+            ->till($formattedEndDayOfWeek, $formattedEndDate)
             ->appendAvailability($offer->getStatus(), $offer->getBookingAvailability())
             ->toString();
     }

--- a/src/Periodic/SmallPeriodicHTMLFormatter.php
+++ b/src/Periodic/SmallPeriodicHTMLFormatter.php
@@ -64,13 +64,13 @@ final class SmallPeriodicHTMLFormatter implements PeriodicFormatterInterface
 
     private function formatDate(DateTimeInterface $date): string
     {
-        $dateFromDay = $this->formatter->formatAsDayNumber($date);
-        $dateFromMonth = $this->formatter->formatAsAbbreviatedMonthName($date);
-        $dateFromYear = $this->formatter->formatAsYear($date);
+        $formattedDate = '<span class="cf-days">' . $this->formatter->formatAsAbbreviatedDayOfWeek($date) . '</span> ' .
+            '<span class="cf-date">' . $this->formatter->formatAsDayNumber($date) . '</span> ' .
+            '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($date) . '</span>';
 
-        return
-            '<span class="cf-date">' . $dateFromDay . '</span> ' .
-            '<span class="cf-month">' . $dateFromMonth . '</span> ' .
-            '<span class="cf-year">' . $dateFromYear . '</span>';
+        if (!DateComparison::isCurrentYear($date)) {
+            $formattedDate .= ' <span class="cf-year">' . $this->formatter->formatAsYear($date) . '</span>';
+        }
+        return $formattedDate;
     }
 }

--- a/src/Periodic/SmallPeriodicPlainTextFormatter.php
+++ b/src/Periodic/SmallPeriodicPlainTextFormatter.php
@@ -50,9 +50,13 @@ final class SmallPeriodicPlainTextFormatter implements PeriodicFormatterInterfac
 
     private function formatDate(DateTimeInterface $date): string
     {
-        $dayNumber = $this->formatter->formatAsDayNumber($date);
-        $monthName = $this->formatter->formatAsAbbreviatedMonthName($date);
-        $year = $this->formatter->formatAsYear($date);
-        return PlainTextSummaryBuilder::singleLine($dayNumber, $monthName, $year);
+        $formattedDate = $this->formatter->formatAsAbbreviatedDayOfWeek($date) . ' '
+            . $this->formatter->formatAsDayNumber($date) . ' '
+            . $this->formatter->formatAsAbbreviatedMonthName($date);
+
+        if (!DateComparison::isCurrentYear($date)) {
+            $formattedDate .= ' ' . $this->formatter->formatAsYear($date);
+        }
+        return $formattedDate;
     }
 }

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -77,6 +77,11 @@ final class PlainTextSummaryBuilder
         return $this->appendTranslation('till')->appendMultiple($text, ' ');
     }
 
+    public function to(string ...$text): self
+    {
+        return $this->appendTranslation('to')->appendMultiple($text, ' ');
+    }
+
     public function tillHour(string ...$text): self
     {
         return $this->appendTranslation('till_hour')->appendMultiple($text, ' ');

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -43,6 +43,7 @@ final class Translator
                 'today' => 'Today',
                 'tonight' => 'Tonight',
                 'tomorrow' => 'Tomorrow',
+                'to' => 'to',
             ],
             'nl' => [
                 'from' => 'van',
@@ -65,6 +66,7 @@ final class Translator
                 'today' => 'Vandaag',
                 'tonight' => 'Vanavond',
                 'tomorrow' => 'Morgen',
+                'to' => 'tot en met',
             ],
             'fr' => [
                 'from' => 'du',
@@ -87,6 +89,7 @@ final class Translator
                 'today' => 'Aujourd\'hui',
                 'tonight' => 'Ce soir',
                 'tomorrow' => 'Demain',
+                'to' => 'à',
             ],
             'de' => [
                 'from' => 'von',
@@ -109,6 +112,7 @@ final class Translator
                 'today' => 'Heute',
                 'tonight' => 'Diesen Abend',
                 'tomorrow' => 'Morgen',
+                'to' => 'bis',
             ],
         ];
 

--- a/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,55 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallPeriodicHTMLFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+    }
+
+    public function testFormatAPeriodStartsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2021'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::periodic()
+        );
+
+        $expected =
+            '<span class="from meta">Vanaf</span>' .
+            ' ' .
+            '<span class="cf-date">25</span>' .
+            '/' .
+            '<span class="cf-month">nov</span>';
+
+        $this->assertEquals(
+            $expected,
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodEndsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-01-2020'),
+            new DateTimeImmutable('30-01-2021'),
+            CalendarType::periodic()
+        );
+
+        $expected =
+            '<span class="to meta">Tot</span>' .
+            ' ' .
+            '<span class="cf-date">30</span>' .
+            '/' .
+            '<span class="cf-month">jan</span>';
+
+        $this->assertEquals(
+            $expected,
+            $this->formatter->format($offer)
+        );
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
@@ -41,9 +41,9 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
             ' ' .
             '<span class="cf-date">25</span>' .
             '/' .
-            '<span class="cf-month">11</span>' .
+            '<span class="cf-month">nov</span>' .
             '/' .
-            '<span class="cf-year">25</span>';
+            '<span class="cf-year">2025</span>';
 
         $this->assertEquals(
             $expected,
@@ -67,9 +67,9 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
             ' ' .
             '<span class="cf-date">4</span>' .
             '/' .
-            '<span class="cf-month">3</span>' .
+            '<span class="cf-month">mrt</span>' .
             '/' .
-            '<span class="cf-year">25</span>';
+            '<span class="cf-year">2025</span>';
 
         $this->assertEquals(
             $expected,
@@ -93,9 +93,9 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
             ' ' .
             '<span class="cf-date">25</span>' .
             '/' .
-            '<span class="cf-month">11</span>' .
+            '<span class="cf-month">nov</span>' .
             '/' .
-            '<span class="cf-year">25</span>' .
+            '<span class="cf-year">2025</span>' .
             ' ' .
             '<span class="cf-status">(geannuleerd)</span>';
 
@@ -121,9 +121,9 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
             ' ' .
             '<span class="cf-date">25</span>' .
             '/' .
-            '<span class="cf-month">3</span>' .
+            '<span class="cf-month">mrt</span>' .
             '/' .
-            '<span class="cf-year">25</span>';
+            '<span class="cf-year">2025</span>';
 
         $this->assertEquals(
             $expected,
@@ -147,9 +147,9 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
             ' ' .
             '<span class="cf-date">4</span>' .
             '/' .
-            '<span class="cf-month">10</span>' .
+            '<span class="cf-month">okt</span>' .
             '/' .
-            '<span class="cf-year">25</span>';
+            '<span class="cf-year">2025</span>';
 
         $this->assertEquals(
             $expected,
@@ -173,9 +173,9 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
             ' ' .
             '<span class="cf-date">18</span>' .
             '/' .
-            '<span class="cf-month">3</span>' .
+            '<span class="cf-month">mrt</span>' .
             '/' .
-            '<span class="cf-year">30</span>';
+            '<span class="cf-year">2030</span>';
 
         $this->assertEquals(
             $expected,

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -122,7 +122,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Tot 18/3/30',
+            'Tot 18 mrt 2030',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -37,7 +37,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 25/11/25',
+            'Vanaf 25 nov 2025',
             $this->formatter->format($offer)
         );
     }
@@ -54,7 +54,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 4/3/25',
+            'Vanaf 4 mrt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -71,7 +71,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 25/11/25 (geannuleerd)',
+            'Vanaf 25 nov 2025 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -88,7 +88,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 25/3/25',
+            'Vanaf 25 mrt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -105,7 +105,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 4/10/25',
+            'Vanaf 4 okt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -139,7 +139,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Tot 18/3/30 (geannuleerd)',
+            'Tot 18 mrt 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void
@@ -72,6 +74,40 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
 
         $this->assertEquals(
             'Vanaf 25 nov 2025 (geannuleerd)',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodStartsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2021'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::periodic()
+        );
+
+        $this->assertEquals(
+            'Vanaf 25 nov',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodEndsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2015'),
+            new DateTimeImmutable('30-11-2021'),
+            CalendarType::periodic()
+        );
+
+        $this->assertEquals(
+            'Tot 30 nov',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/LargePeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/LargePeriodicHTMLFormatterTest.php
@@ -54,10 +54,12 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-period"> '
+            . '<span class="cf-weekday cf-meta">dinsdag</span> '
             . '<time itemprop="startDate" datetime="2025-11-25"> '
             . '<span class="cf-date">25 november 2025</span> '
             . '</time> '
-            . '<span class="cf-to cf-meta">tot</span> '
+            . '<span class="cf-to cf-meta">tot en met</span> '
+            . '<span class="cf-weekday cf-meta">zaterdag</span> '
             . '<time itemprop="endDate" datetime="2030-11-30"> '
             . '<span class="cf-date">30 november 2030</span> '
             . '</time> '
@@ -136,10 +138,12 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-period"> '
+            . '<span class="cf-weekday cf-meta">mardi</span> '
             . '<time itemprop="startDate" datetime="2025-11-25"> '
             . '<span class="cf-date">25 novembre 2025</span> '
             . '</time> '
-            . '<span class="cf-to cf-meta">au</span> '
+            . '<span class="cf-to cf-meta">à</span> '
+            . '<span class="cf-weekday cf-meta">samedi</span> '
             . '<time itemprop="endDate" datetime="2030-11-30"> '
             . '<span class="cf-date">30 novembre 2030</span> '
             . '</time> '
@@ -194,10 +198,12 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-period"> '
+            . '<span class="cf-weekday cf-meta">dinsdag</span> '
             . '<time itemprop="startDate" datetime="2025-11-25"> '
             . '<span class="cf-date">25 november 2025</span> '
             . '</time> '
-            . '<span class="cf-to cf-meta">tot</span> '
+            . '<span class="cf-to cf-meta">tot en met</span> '
+            . '<span class="cf-weekday cf-meta">zaterdag</span> '
             . '<time itemprop="endDate" datetime="2030-11-30"> '
             . '<span class="cf-date">30 november 2030</span> '
             . '</time> '
@@ -287,10 +293,12 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-period"> '
+            . '<span class="cf-weekday cf-meta">dinsdag</span> '
             . '<time itemprop="startDate" datetime="2025-11-25"> '
             . '<span class="cf-date">25 november 2025</span> '
             . '</time> '
-            . '<span class="cf-to cf-meta">tot</span> '
+            . '<span class="cf-to cf-meta">tot en met</span> '
+            . '<span class="cf-weekday cf-meta">zaterdag</span> '
             . '<time itemprop="endDate" datetime="2030-11-30"> '
             . '<span class="cf-date">30 november 2030</span> '
             . '</time> '
@@ -404,10 +412,12 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-period"> '
+            . '<span class="cf-weekday cf-meta">dinsdag</span> '
             . '<time itemprop="startDate" datetime="2025-11-25"> '
             . '<span class="cf-date">25 november 2025</span> '
             . '</time> '
-            . '<span class="cf-to cf-meta">tot</span> '
+            . '<span class="cf-to cf-meta">tot en met</span> '
+            . '<span class="cf-weekday cf-meta">zaterdag</span> '
             . '<time itemprop="endDate" datetime="2030-11-30"> '
             . '<span class="cf-date">30 november 2030</span> '
             . '</time> '
@@ -475,10 +485,12 @@ final class LargePeriodicHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<p class="cf-period"> '
+            . '<span class="cf-weekday cf-meta">dinsdag</span> '
             . '<time itemprop="startDate" datetime="2025-11-25"> '
             . '<span class="cf-date">25 november 2025</span> '
             . '</time> '
-            . '<span class="cf-to cf-meta">tot</span> '
+            . '<span class="cf-to cf-meta">tot en met</span> '
+            . '<span class="cf-weekday cf-meta">zaterdag</span> '
             . '<time itemprop="endDate" datetime="2030-11-30"> '
             . '<span class="cf-date">30 november 2030</span> '
             . '</time> '

--- a/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/LargePeriodicPlainTextFormatterTest.php
@@ -53,7 +53,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030' . PHP_EOL
+            'Van dinsdag 25 november 2025 tot en met zaterdag 30 november 2030' . PHP_EOL
             . '(maandag van 0:01 tot 17:00, '
             . 'dinsdag van 0:01 tot 17:00, '
             . 'woensdag van 0:01 tot 17:00, '
@@ -90,7 +90,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Du 25 novembre 2025 au 30 novembre 2030' . PHP_EOL
+            'Du mardi 25 novembre 2025 à samedi 30 novembre 2030' . PHP_EOL
             . '(lundi de 0:01 à 17:00, '
             . 'vendredi de 10:00 à 18:00)',
             (new LargePeriodicPlainTextFormatter(new Translator('fr')))->format($place)
@@ -124,7 +124,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030' . PHP_EOL
+            'Van dinsdag 25 november 2025 tot en met zaterdag 30 november 2030' . PHP_EOL
             . '(maandag van 0:01 tot 17:00, '
             . 'dinsdag van 0:01 tot 17:00, '
             . 'woensdag van 0:01 tot 17:00, '
@@ -171,7 +171,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030' . PHP_EOL
+            'Van dinsdag 25 november 2025 tot en met zaterdag 30 november 2030' . PHP_EOL
             . '(maandag van 9:00 tot 13:00 en van 17:00 tot 20:00, '
             . 'dinsdag van 9:00 tot 13:00 en van 17:00 tot 20:00, '
             . 'woensdag van 9:00 tot 13:00 en van 17:00 tot 20:00, '
@@ -223,7 +223,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030' . PHP_EOL
+            'Van dinsdag 25 november 2025 tot en met zaterdag 30 november 2030' . PHP_EOL
             . '(maandag van 9:30 tot 13:45 en van 17:00 tot 20:00, '
             . 'dinsdag van 9:30 tot 13:45 en van 18:00 tot 20:00 en van 21:00 tot 23:00, '
             . 'vrijdag van 10:00 tot 15:00, '
@@ -244,7 +244,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030',
+            'Van dinsdag 25 november 2025 tot en met zaterdag 30 november 2030',
             $this->formatter->format($place)
         );
     }
@@ -261,7 +261,7 @@ final class LargePeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030 (geannuleerd)',
+            'Van dinsdag 25 november 2025 tot en met zaterdag 30 november 2030 (geannuleerd)',
             $this->formatter->format($event)
         );
     }

--- a/tests/Periodic/MediumPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicHTMLFormatterTest.php
@@ -37,8 +37,10 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 november 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 november 2030</span>',
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-weekday cf-meta">di</span> ' .
+            '<span class="cf-date">25 november 2025</span> ' .
+            '<span class="cf-to cf-meta">tot</span> <span class="cf-weekday cf-meta">za</span> ' .
+            '<span class="cf-date">30 november 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -55,8 +57,10 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">4 maart 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">8 maart 2030</span>',
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-weekday cf-meta">di</span> ' .
+            '<span class="cf-date">4 maart 2025</span> ' .
+            '<span class="cf-to cf-meta">tot</span> <span class="cf-weekday cf-meta">vr</span> ' .
+            '<span class="cf-date">8 maart 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -73,8 +77,10 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 november 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 november 2030</span>'
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-weekday cf-meta">di</span> '
+            . '<span class="cf-date">25 november 2025</span> '
+            . '<span class="cf-to cf-meta">tot</span> <span class="cf-weekday cf-meta">za</span> '
+            . '<span class="cf-date">30 november 2030</span>'
             . ' <span class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($offer)
         );
@@ -92,8 +98,10 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">25 maart 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">30 maart 2030</span>',
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-weekday cf-meta">di</span> ' .
+            '<span class="cf-date">25 maart 2025</span> '
+            . '<span class="cf-to cf-meta">tot</span> <span class="cf-weekday cf-meta">za</span> '
+            . '<span class="cf-date">30 maart 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -110,8 +118,10 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">4 oktober 2025</span> '
-            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">8 oktober 2030</span>',
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-weekday cf-meta">za</span>'
+            . ' <span class="cf-date">4 oktober 2025</span> '
+            . '<span class="cf-to cf-meta">tot</span> '
+            . '<span class="cf-weekday cf-meta">di</span> <span class="cf-date">8 oktober 2030</span>',
             $this->formatter->format($offer)
         );
     }
@@ -127,7 +137,7 @@ final class MediumPeriodicHTMLFormatterTest extends TestCase
             CalendarType::periodic()
         );
 
-        $output = '<span class="cf-weekday cf-meta">Woensdag</span>';
+        $output = '<span class="cf-weekday cf-meta">Wo</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">8 oktober 2025</span>';
 

--- a/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/MediumPeriodicPlainTextFormatterTest.php
@@ -37,7 +37,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030',
+            'Van di 25 november 2025 tot za 30 november 2030',
             $this->formatter->format($offer)
         );
     }
@@ -54,7 +54,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4 maart 2025 tot 8 maart 2030',
+            'Van di 4 maart 2025 tot vr 8 maart 2030',
             $this->formatter->format($offer)
         );
     }
@@ -71,7 +71,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 november 2025 tot 30 november 2030 (geannuleerd)',
+            'Van di 25 november 2025 tot za 30 november 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -88,7 +88,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 maart 2025 tot 30 maart 2030',
+            'Van di 25 maart 2025 tot za 30 maart 2030',
             $this->formatter->format($offer)
         );
     }
@@ -105,7 +105,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 4 oktober 2025 tot 8 oktober 2030',
+            'Van za 4 oktober 2025 tot di 8 oktober 2030',
             $this->formatter->format($offer)
         );
     }
@@ -122,7 +122,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 maart 2025 tot 30 maart 2030 (geannuleerd)',
+            'Van di 25 maart 2025 tot za 30 maart 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -139,7 +139,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Woensdag 8 oktober 2025',
+            'Wo 8 oktober 2025',
             $this->formatter->format($offer)
         );
     }
@@ -156,7 +156,7 @@ final class MediumPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Woensdag 8 oktober 2025 (geannuleerd)',
+            'Wo 8 oktober 2025 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }

--- a/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallPeriodicHTMLFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void
@@ -38,6 +40,8 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
 
         $expected =
             '<span class="from meta">Vanaf</span>' .
+            ' ' .
+            '<span class="cf-days">di</span>' .
             ' ' .
             '<span class="cf-date">25</span>' .
             ' ' .
@@ -65,11 +69,91 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $expected =
             '<span class="from meta">Vanaf</span>' .
             ' ' .
+            '<span class="cf-days">di</span>' .
+            ' ' .
             '<span class="cf-date">4</span>' .
             ' ' .
             '<span class="cf-month">mrt</span>' .
             ' ' .
             '<span class="cf-year">2025</span>';
+
+        $this->assertEquals(
+            $expected,
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2021'),
+            new DateTimeImmutable('30-11-2021'),
+            CalendarType::periodic()
+        );
+
+        $expected =
+            '<span class="from meta">Vanaf</span>' .
+            ' ' .
+            '<span class="cf-days">do</span>' .
+            ' ' .
+            '<span class="cf-date">25</span>' .
+            ' ' .
+            '<span class="cf-month">nov</span>';
+
+        $this->assertEquals(
+            $expected,
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodStartsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2021'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::periodic()
+        );
+
+        $expected =
+            '<span class="from meta">Vanaf</span>' .
+            ' ' .
+            '<span class="cf-days">do</span>' .
+            ' ' .
+            '<span class="cf-date">25</span>' .
+            ' ' .
+            '<span class="cf-month">nov</span>';
+
+        $this->assertEquals(
+            $expected,
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodEndsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('04-03-2020'),
+            new DateTimeImmutable('08-03-2021'),
+            CalendarType::periodic()
+        );
+
+        $expected =
+            '<span class="to meta">Tot</span>' .
+            ' ' .
+            '<span class="cf-days">ma</span>' .
+            ' ' .
+            '<span class="cf-date">8</span>' .
+            ' ' .
+            '<span class="cf-month">mrt</span>';
 
         $this->assertEquals(
             $expected,
@@ -90,6 +174,8 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
 
         $expected =
             '<span class="from meta">Vanaf</span>' .
+            ' ' .
+            '<span class="cf-days">di</span>' .
             ' ' .
             '<span class="cf-date">25</span>' .
             ' ' .
@@ -119,6 +205,8 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $expected =
             '<span class="from meta">Vanaf</span>' .
             ' ' .
+            '<span class="cf-days">di</span>' .
+            ' ' .
             '<span class="cf-date">25</span>' .
             ' ' .
             '<span class="cf-month">mrt</span>' .
@@ -145,6 +233,8 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
         $expected =
             '<span class="from meta">Vanaf</span>' .
             ' ' .
+            '<span class="cf-days">za</span>' .
+            ' ' .
             '<span class="cf-date">4</span>' .
             ' ' .
             '<span class="cf-month">okt</span>' .
@@ -170,6 +260,8 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
 
         $expected =
             '<span class="to meta">Tot</span>' .
+            ' ' .
+            '<span class="cf-days">ma</span>' .
             ' ' .
             '<span class="cf-date">18</span>' .
             ' ' .

--- a/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -23,6 +24,41 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+    }
+
+    public function testFormatAPeriodStartsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2021'),
+            new DateTimeImmutable('30-11-2030'),
+            CalendarType::periodic()
+        );
+
+        $this->assertEquals(
+            'Vanaf do 25 nov',
+            $this->formatter->format($offer)
+        );
+    }
+
+    public function testFormatAPeriodEndsCurrentYear(): void
+    {
+        $offer = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2015'),
+            new DateTimeImmutable('22-02-2021'),
+            CalendarType::periodic()
+        );
+
+        $this->assertEquals(
+            'Tot ma 22 feb',
+            $this->formatter->format($offer)
+        );
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void
@@ -37,7 +73,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 25 nov 2025',
+            'Vanaf di 25 nov 2025',
             $this->formatter->format($offer)
         );
     }
@@ -54,7 +90,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 4 mrt 2025',
+            'Vanaf di 4 mrt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -71,7 +107,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 25 nov 2025 (geannuleerd)',
+            'Vanaf di 25 nov 2025 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }
@@ -88,7 +124,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 25 mrt 2025',
+            'Vanaf di 25 mrt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -105,7 +141,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Vanaf 4 okt 2025',
+            'Vanaf za 4 okt 2025',
             $this->formatter->format($offer)
         );
     }
@@ -122,7 +158,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Tot 18 mrt 2030',
+            'Tot ma 18 mrt 2030',
             $this->formatter->format($offer)
         );
     }
@@ -139,7 +175,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Tot 18 mrt 2030 (geannuleerd)',
+            'Tot ma 18 mrt 2030 (geannuleerd)',
             $this->formatter->format($offer)
         );
     }


### PR DESCRIPTION
### Changed

1.`xs` 
- omit the year if it is not the current year
- use abbreviated month instead of number

2.`sm`
- omit the year if it is not the current year
- add abbreviated weekday

3.`md`
- Days are never written in full but abbreviated

4.`lg`
- Add weekday in full
- Use `tot en met` instead of `tot`

---

Ticket: https://jira.uitdatabank.be/browse/III-4499
