### PR TITLE
III-5087 CalendarType Permanent with hours

### DIFF
--- a/src/DateFormatter.php
+++ b/src/DateFormatter.php
@@ -15,6 +15,7 @@ final class DateFormatter
     private const PATTERN_DAY_NUMBER = 'd'; // Example '1', '31'
     private const PATTERN_MONTH_NUMBER = 'M'; // Example '1', '12'
 
+    private const PATTERN_DAY_OF_WEEK_NR = 'e'; // Example '1', '7'
     private const PATTERN_DAY_OF_WEEK = 'EEEE'; // Example 'tuesday'
     private const PATTERN_DAY_OF_WEEK_ABBREVIATED = 'EEE'; // Example 'tue'
 
@@ -60,6 +61,14 @@ final class DateFormatter
     public function formatAsDayOfWeek(DateTimeInterface $dateTime): string
     {
         return $this->format($dateTime, self::PATTERN_DAY_OF_WEEK);
+    }
+
+    /**
+     * Used to format weekdays as '1' to '7'
+     */
+    public function formatAsDayOfWeekNumber(DateTimeInterface $dateTime): string
+    {
+        return $this->format($dateTime, self::PATTERN_DAY_OF_WEEK_NR);
     }
 
     /**

--- a/src/Permanent/LargePermanentPlainTextFormatter.php
+++ b/src/Permanent/LargePermanentPlainTextFormatter.php
@@ -69,7 +69,7 @@ final class LargePermanentPlainTextFormatter implements PermanentFormatterInterf
         $formattedDays = [];
         foreach ($dayNames as $dayName) {
             $formattedDays[$dayName] = PlainTextSummaryBuilder::start($this->translator)
-                ->append($this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName)));
+                ->append($this->formatter->formatAsDayOfWeek(new DateTimeImmutable($dayName)));
         }
 
         // Keep track of which day (names) have opening hours, so we know which days are closed.

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -13,6 +13,8 @@ use DateTimeImmutable;
 
 final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
 {
+    use MediumPermanentWeekScheme;
+
     /**
      * @var DateFormatter
      */
@@ -73,37 +75,15 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
             return '<p class="cf-openinghours">Elke ' . $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])) . ' open</p>';
         }
 
-        $translatedDayNamesWithOpeningHours = [];
-        $dayPeriod = '';
-        $startNewPeriod = true;
-        foreach ($weekDaysOpen as $weekDayNumber => $dayName) {
-            // We start a new period, but the following day is closed
-            if ($startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $translatedDayNamesWithOpeningHours[] = $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-            }
-            // Start a new period and the following day is open
-            if ($startNewPeriod && array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $dayPeriod = $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-                $startNewPeriod = false;
-            }
-            // The previous day was open but the following day isn't
-            if (!$startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $dayPeriod .= ' - ' . $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-                $translatedDayNamesWithOpeningHours[] = $dayPeriod;
-                $startNewPeriod = true;
-                $dayPeriod = '';
-            }
-            // Do nothing if both the previous & following day are open
-        }
+        $weekScheme = $this->getWeekScheme($weekDaysOpen, $this->formatter);
 
         $outputWeek = '<span>' . ucfirst($this->translator->translate('open')) . ' '
             . '<span class="cf-weekdays">';
 
         $i = 0;
-
-        foreach ($translatedDayNamesWithOpeningHours as $translatedDayNamesWithOpeningHour) {
+        foreach ($weekScheme as $translatedDayNamesWithOpeningHour) {
             $outputWeek .= '<span class="cf-weekday-open">' . $translatedDayNamesWithOpeningHour . '</span>';
-            if (++$i !== count($translatedDayNamesWithOpeningHours)) {
+            if (++$i !== count($weekScheme)) {
                 $outputWeek .= ' & ';
             }
         }

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -74,7 +74,7 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
         if (count($weekDaysOpen) === 1) {
             return '<p class="cf-openinghours">' .
                 $this->translator->translate('open_every') . ' ' .
-                $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])) . ' ' .
+                $this->formatter->formatAsDayOfWeek(new DateTimeImmutable(reset($weekDaysOpen))) . ' ' .
                 $this->translator->translate('open_every_end') . '</p>';
         }
 

--- a/src/Permanent/MediumPermanentHTMLFormatter.php
+++ b/src/Permanent/MediumPermanentHTMLFormatter.php
@@ -72,7 +72,10 @@ final class MediumPermanentHTMLFormatter implements PermanentFormatterInterface
         }
 
         if (count($weekDaysOpen) === 1) {
-            return '<p class="cf-openinghours">Elke ' . $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])) . ' open</p>';
+            return '<p class="cf-openinghours">' .
+                $this->translator->translate('open_every') . ' ' .
+                $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])) . ' ' .
+                $this->translator->translate('open_every_end') . '</p>';
         }
 
         $weekScheme = $this->getWeekScheme($weekDaysOpen, $this->formatter);

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -76,7 +76,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
         }
 
         $translatedDayNamesWithOpeningHours = [];
-        $subString = '';
+        $dayPeriod = '';
         $startNewPeriod = true;
         foreach ($weekDaysOpen as $weekDayNumber => $dayName) {
             // We start a new period, but the following day is closed
@@ -85,15 +85,15 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
             }
             // Start a new period and the following day is open
             if ($startNewPeriod && array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $subString = $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
+                $dayPeriod = $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
                 $startNewPeriod = false;
             }
             // The previous day was open but the following day isn't
             if (!$startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $subString .= ' - ' . $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-                $translatedDayNamesWithOpeningHours[] = $subString;
+                $dayPeriod .= ' - ' . $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
+                $translatedDayNamesWithOpeningHours[] = $dayPeriod;
                 $startNewPeriod = true;
-                $subString = '';
+                $dayPeriod = '';
             }
             // Do nothing if both the previous & following day are open
         }

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -13,6 +13,8 @@ use DateTimeImmutable;
 
 final class MediumPermanentPlainTextFormatter implements PermanentFormatterInterface
 {
+    use MediumPermanentWeekScheme;
+
     /**
      * @var DateFormatter
      */
@@ -75,33 +77,12 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
             return 'Elke ' . $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])) . ' open';
         }
 
-        $translatedDayNamesWithOpeningHours = [];
-        $dayPeriod = '';
-        $startNewPeriod = true;
-        foreach ($weekDaysOpen as $weekDayNumber => $dayName) {
-            // We start a new period, but the following day is closed
-            if ($startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $translatedDayNamesWithOpeningHours[] = $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-            }
-            // Start a new period and the following day is open
-            if ($startNewPeriod && array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $dayPeriod = $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-                $startNewPeriod = false;
-            }
-            // The previous day was open but the following day isn't
-            if (!$startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
-                $dayPeriod .= ' - ' . $this->formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
-                $translatedDayNamesWithOpeningHours[] = $dayPeriod;
-                $startNewPeriod = true;
-                $dayPeriod = '';
-            }
-            // Do nothing if both the previous & following day are open
-        }
+        $weekScheme = $this->getWeekScheme($weekDaysOpen, $this->formatter);
 
         // Put all the day names with opening hours on a single line with 'Open at' (sec) at the beginning.
         // E.g. 'Open at mo - th & su'
         return PlainTextSummaryBuilder::start($this->translator)
-            ->openAt(...$translatedDayNamesWithOpeningHours)
+            ->openAt(...$weekScheme)
             ->toString();
     }
 }

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -99,7 +99,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
         }
 
         // Put all the day names with opening hours on a single line with 'Open at' (sec) at the beginning.
-        // E.g. 'Open at monday - thursday & sunday'
+        // E.g. 'Open at mo - th & su'
         return PlainTextSummaryBuilder::start($this->translator)
             ->openAt(...$translatedDayNamesWithOpeningHours)
             ->toString();

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -76,7 +76,7 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
         if (count($weekDaysOpen) === 1) {
             return PlainTextSummaryBuilder::start($this->translator)
                 ->append($this->translator->translate('open_every'))
-                ->append($this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])))
+                ->append($this->formatter->formatAsDayOfWeek(new DateTimeImmutable(reset($weekDaysOpen))))
                 ->append($this->translator->translate('open_every_end'))
                 ->toString();
         }

--- a/src/Permanent/MediumPermanentPlainTextFormatter.php
+++ b/src/Permanent/MediumPermanentPlainTextFormatter.php
@@ -74,7 +74,11 @@ final class MediumPermanentPlainTextFormatter implements PermanentFormatterInter
         }
 
         if (count($weekDaysOpen) === 1) {
-            return 'Elke ' . $this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])) . ' open';
+            return PlainTextSummaryBuilder::start($this->translator)
+                ->append($this->translator->translate('open_every'))
+                ->append($this->formatter->formatAsDayOfWeek(new DateTimeImmutable($weekDaysOpen[key($weekDaysOpen)])))
+                ->append($this->translator->translate('open_every_end'))
+                ->toString();
         }
 
         $weekScheme = $this->getWeekScheme($weekDaysOpen, $this->formatter);

--- a/src/Permanent/MediumPermanentWeekScheme.php
+++ b/src/Permanent/MediumPermanentWeekScheme.php
@@ -11,9 +11,12 @@ trait MediumPermanentWeekScheme
 {
     public function getWeekScheme(array $weekDaysOpen, DateFormatter $formatter): array
     {
+        // Do no assume people will order the days consecutive
+        ksort($weekDaysOpen);
         $translatedDayNamesWithOpeningHours = [];
         $dayPeriod = '';
         $startNewPeriod = true;
+
         foreach ($weekDaysOpen as $weekDayNumber => $dayName) {
             // We start a new period, but the following day is closed
             if ($startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {

--- a/src/Permanent/MediumPermanentWeekScheme.php
+++ b/src/Permanent/MediumPermanentWeekScheme.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3\Permanent;
+
+use CultuurNet\CalendarSummaryV3\DateFormatter;
+use DateTimeImmutable;
+
+trait MediumPermanentWeekScheme
+{
+    public function getWeekScheme(array $weekDaysOpen, DateFormatter $formatter): array
+    {
+        $translatedDayNamesWithOpeningHours = [];
+        $dayPeriod = '';
+        $startNewPeriod = true;
+        foreach ($weekDaysOpen as $weekDayNumber => $dayName) {
+            // We start a new period, but the following day is closed
+            if ($startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
+                $translatedDayNamesWithOpeningHours[] = $formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
+            }
+            // Start a new period and the following day is open
+            if ($startNewPeriod && array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
+                $dayPeriod = $formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
+                $startNewPeriod = false;
+            }
+            // The previous day was open but the following day isn't
+            if (!$startNewPeriod && !array_key_exists($weekDayNumber + 1, $weekDaysOpen)) {
+                $dayPeriod .= ' - ' . $formatter->formatAsAbbreviatedDayOfWeek(new DateTimeImmutable($dayName));
+                $translatedDayNamesWithOpeningHours[] = $dayPeriod;
+                $startNewPeriod = true;
+                $dayPeriod = '';
+            }
+            // Do nothing if both the previous & following day are open
+        }
+
+        return $translatedDayNamesWithOpeningHours;
+    }
+}

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -44,7 +44,7 @@ final class PlainTextSummaryBuilder
 
     public function openAt(string ...$text): self
     {
-        return $this->appendTranslation('open')->appendMultiple($text, ', ');
+        return $this->appendTranslation('open')->appendMultiple($text, ' & ');
     }
 
     public function alwaysOpen(): self

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -44,6 +44,8 @@ final class Translator
                 'tonight' => 'Tonight',
                 'tomorrow' => 'Tomorrow',
                 'to' => 'to',
+                'open_every' => 'Open every',
+                'open_every_end' => '',
             ],
             'nl' => [
                 'from' => 'van',
@@ -67,6 +69,8 @@ final class Translator
                 'tonight' => 'Vanavond',
                 'tomorrow' => 'Morgen',
                 'to' => 'tot en met',
+                'open_every' => 'Elke',
+                'open_every_end' => 'open',
             ],
             'fr' => [
                 'from' => 'du',
@@ -90,6 +94,8 @@ final class Translator
                 'tonight' => 'Ce soir',
                 'tomorrow' => 'Demain',
                 'to' => 'à',
+                'open_every' => 'Ouvert chaque',
+                'open_every_end' => '',
             ],
             'de' => [
                 'from' => 'von',
@@ -113,6 +119,8 @@ final class Translator
                 'tonight' => 'Diesen Abend',
                 'tomorrow' => 'Morgen',
                 'to' => 'bis',
+                'open_every' => 'Jeden',
+                'open_every_end' => 'geöffnet',
             ],
         ];
 

--- a/tests/Permanent/LargePermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/LargePermanentPlainTextFormatterTest.php
@@ -63,13 +63,13 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Ma van 9:00 tot 13:00' . PHP_EOL
-            . 'Di van 9:00 tot 13:00' . PHP_EOL
-            . 'Wo van 9:00 tot 13:00' . PHP_EOL
-            . 'Do gesloten' . PHP_EOL
-            . 'Vr van 0:01 tot 13:00' . PHP_EOL
-            . 'Za van 9:00 tot 19:00' . PHP_EOL
-            . 'Zo van 9:00 tot 19:00' . PHP_EOL,
+            'Maandag van 9:00 tot 13:00' . PHP_EOL
+            . 'Dinsdag van 9:00 tot 13:00' . PHP_EOL
+            . 'Woensdag van 9:00 tot 13:00' . PHP_EOL
+            . 'Donderdag gesloten' . PHP_EOL
+            . 'Vrijdag van 0:01 tot 13:00' . PHP_EOL
+            . 'Zaterdag van 9:00 tot 19:00' . PHP_EOL
+            . 'Zondag van 9:00 tot 19:00' . PHP_EOL,
             $this->formatter->format($place)
         );
     }
@@ -104,13 +104,13 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Lun. de 9:00 à 13:00' . PHP_EOL
-            . 'Mar. fermé' . PHP_EOL
-            . 'Mer. fermé' . PHP_EOL
-            . 'Jeu. fermé' . PHP_EOL
-            . 'Ven. de 0:01 à 13:00' . PHP_EOL
-            . 'Sam. fermé' . PHP_EOL
-            . 'Dim. fermé' . PHP_EOL,
+            'Lundi de 9:00 à 13:00' . PHP_EOL
+            . 'Mardi fermé' . PHP_EOL
+            . 'Mercredi fermé' . PHP_EOL
+            . 'Jeudi fermé' . PHP_EOL
+            . 'Vendredi de 0:01 à 13:00' . PHP_EOL
+            . 'Samedi fermé' . PHP_EOL
+            . 'Dimanche fermé' . PHP_EOL,
             (new LargePermanentPlainTextFormatter(new Translator('fr')))->format($place)
         );
     }
@@ -159,13 +159,13 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Ma van 9:00 tot 13:00' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
-            . 'Di van 9:00 tot 13:00' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
-            . 'Wo van 9:00 tot 13:00' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
-            . 'Do gesloten' . PHP_EOL
-            . 'Vr van 10:00 tot 15:00' . PHP_EOL . 'van 18:00 tot 21:00' . PHP_EOL
-            . 'Za van 10:00 tot 15:00' . PHP_EOL . 'van 18:00 tot 21:00' . PHP_EOL
-            . 'Zo gesloten' . PHP_EOL,
+            'Maandag van 9:00 tot 13:00' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
+            . 'Dinsdag van 9:00 tot 13:00' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
+            . 'Woensdag van 9:00 tot 13:00' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
+            . 'Donderdag gesloten' . PHP_EOL
+            . 'Vrijdag van 10:00 tot 15:00' . PHP_EOL . 'van 18:00 tot 21:00' . PHP_EOL
+            . 'Zaterdag van 10:00 tot 15:00' . PHP_EOL . 'van 18:00 tot 21:00' . PHP_EOL
+            . 'Zondag gesloten' . PHP_EOL,
             $this->formatter->format($place)
         );
     }
@@ -221,14 +221,14 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Ma van 9:30 tot 13:45' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
-            . 'Di van 9:30 tot 13:45' . PHP_EOL . 'van 18:00 tot 20:00' . PHP_EOL
+            'Maandag van 9:30 tot 13:45' . PHP_EOL . 'van 17:00 tot 20:00' . PHP_EOL
+            . 'Dinsdag van 9:30 tot 13:45' . PHP_EOL . 'van 18:00 tot 20:00' . PHP_EOL
             . 'van 21:00 tot 23:00' . PHP_EOL
-            . 'Wo gesloten' . PHP_EOL
-            . 'Do gesloten' . PHP_EOL
-            . 'Vr van 10:00 tot 15:00' . PHP_EOL
-            . 'Za van 10:00 tot 15:00' . PHP_EOL
-            . 'Zo gesloten' . PHP_EOL,
+            . 'Woensdag gesloten' . PHP_EOL
+            . 'Donderdag gesloten' . PHP_EOL
+            . 'Vrijdag van 10:00 tot 15:00' . PHP_EOL
+            . 'Zaterdag van 10:00 tot 15:00' . PHP_EOL
+            . 'Zondag gesloten' . PHP_EOL,
             $this->formatter->format($place)
         );
     }

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -64,12 +64,8 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<span>Open op <span class="cf-weekdays">'
-            . '<span class="cf-weekday-open">ma</span>, '
-            . '<span class="cf-weekday-open">di</span>, '
-            . '<span class="cf-weekday-open">wo</span>, '
-            . '<span class="cf-weekday-open">vr</span>, '
-            . '<span class="cf-weekday-open">za</span>, '
-            . '<span class="cf-weekday-open">zo</span>'
+            . '<span class="cf-weekday-open">ma - wo</span> & '
+            . '<span class="cf-weekday-open">vr - zo</span>'
             . '</span></span>',
             $this->formatter->format($place)
         );
@@ -120,11 +116,8 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<span>Open op <span class="cf-weekdays">'
-            . '<span class="cf-weekday-open">ma</span>, '
-            . '<span class="cf-weekday-open">di</span>, '
-            . '<span class="cf-weekday-open">wo</span>, '
-            . '<span class="cf-weekday-open">vr</span>, '
-            . '<span class="cf-weekday-open">za</span>'
+            . '<span class="cf-weekday-open">ma - wo</span> & '
+            . '<span class="cf-weekday-open">vr - za</span>'
             . '</span></span>',
             $this->formatter->format($place)
         );
@@ -182,7 +175,7 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<span>Open op <span class="cf-weekdays">'
-            . '<span class="cf-weekday-open">ma</span>, '
+            . '<span class="cf-weekday-open">ma -</span>, '
             . '<span class="cf-weekday-open">di</span>, '
             . '<span class="cf-weekday-open">vr</span>, '
             . '<span class="cf-weekday-open">za</span>'

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -416,6 +416,96 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPermanentThreePeriodsMixedSorting(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['monday', 'tuesday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['friday', 'saturday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['wednesday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            '<span>Open op <span class="cf-weekdays">' .
+            '<span class="cf-weekday-open">ma - wo</span> & ' .
+            '<span class="cf-weekday-open">vr - za</span>' .
+            '</span></span>',
+            $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatPermanentBreakTheWeek(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['monday', 'tuesday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['tuesday', 'saturday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['sunday', 'monday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            '<span>Open op <span class="cf-weekdays">' .
+            '<span class="cf-weekday-open">ma - di</span> & ' .
+            '<span class="cf-weekday-open">za - zo</span>' .
+            '</span></span>',
+            $this->formatter->format($place)
+        );
+    }
+
     public function testFormatPermanentWithoutOpeningHours(): void
     {
         $event = new Offer(

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -175,10 +175,8 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
 
         $this->assertEquals(
             '<span>Open op <span class="cf-weekdays">'
-            . '<span class="cf-weekday-open">ma -</span>, '
-            . '<span class="cf-weekday-open">di</span>, '
-            . '<span class="cf-weekday-open">vr</span>, '
-            . '<span class="cf-weekday-open">za</span>'
+            . '<span class="cf-weekday-open">ma - di</span> & '
+            . '<span class="cf-weekday-open">vr - za</span>'
             . '</span></span>',
             $this->formatter->format($place)
         );

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -182,6 +182,95 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPermanentClosedOnMondays(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['wednesday', 'thursday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['friday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['sunday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            '<span>Open op <span class="cf-weekdays">' .
+            '<span class="cf-weekday-open">wo - vr</span> & ' .
+            '<span class="cf-weekday-open">zo</span></span></span>',
+            $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatPermanentThreePeriods(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['monday', 'tuesday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['thursday', 'friday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['sunday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            '<span>Open op <span class="cf-weekdays">' .
+            '<span class="cf-weekday-open">ma - di</span> & ' .
+            '<span class="cf-weekday-open">do - vr</span> & ' .
+            '<span class="cf-weekday-open">zo</span></span></span>',
+            $this->formatter->format($place)
+        );
+    }
+
     public function testFormatAnUnavailablePermanent(): void
     {
         $event = new Offer(

--- a/tests/Permanent/MediumPermanentHTMLFormatterTest.php
+++ b/tests/Permanent/MediumPermanentHTMLFormatterTest.php
@@ -226,6 +226,83 @@ final class MediumPermanentHTMLFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPermanentOpenSevenDayAWeek(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['wednesday', 'thursday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['monday', 'tuesday', 'friday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['saturday', 'sunday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Elke dag open</p>',
+            $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatPermanentOpenOneDayAWeek(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['wednesday'],
+            '09:00',
+            '11:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['wednesday'],
+            '18:00',
+            '20:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+            ]
+        );
+
+        $this->assertEquals(
+            '<p class="cf-openinghours">Elke woensdag open</p>',
+            $this->formatter->format($place)
+        );
+    }
+
     public function testFormatPermanentThreePeriods(): void
     {
         $place = new Offer(

--- a/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
@@ -271,6 +271,90 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         );
     }
 
+    public function testFormatPermanentClosedOnMondays(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['wednesday', 'thursday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['friday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['sunday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            'Open op wo - vr & zo',
+            $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatPermanentThreePeriods(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['monday', 'tuesday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['thursday', 'friday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['sunday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            'Open op ma - di & do - vr & zo',
+            $this->formatter->format($place)
+        );
+    }
+
     public function testFormatPermanentWithoutOpeningHours(): void
     {
         $event = new Offer(

--- a/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/MediumPermanentPlainTextFormatterTest.php
@@ -63,7 +63,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Open op ma, di, wo, vr, za, zo',
+            'Open op ma - wo & vr - zo',
             $this->formatter->format($place)
         );
     }
@@ -112,7 +112,7 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Open op ma, di, wo, vr, za',
+            'Open op ma - wo & vr - za',
             $this->formatter->format($place)
         );
     }
@@ -168,7 +168,105 @@ final class MediumPermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Open op ma, di, vr, za',
+            'Open op ma - di & vr - za',
+            $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatSingleDayPermanent(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['tuesday'],
+            '09:30',
+            '13:45'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['tuesday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['tuesday'],
+            '21:00',
+            '23:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+            ]
+        );
+
+        $this->assertEquals(
+            'Elke dinsdag open',
+            $this->formatter->format($place)
+        );
+    }
+
+    public function testFormatPermanentAllDaysWithHours(): void
+    {
+        $place = new Offer(
+            OfferType::place(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            new DateTimeImmutable('25-11-2025'),
+            new DateTimeImmutable('25-11-2025')
+        );
+
+        $openingHours1 = new OpeningHour(
+            ['monday','tuesday'],
+            '09:30',
+            '13:45'
+        );
+
+        $openingHours2 = new OpeningHour(
+            ['monday'],
+            '17:00',
+            '20:00'
+        );
+
+        $openingHours3 = new OpeningHour(
+            ['wednesday', 'thursday'],
+            '18:00',
+            '20:00'
+        );
+
+        $openingHours4 = new OpeningHour(
+            ['tuesday'],
+            '21:00',
+            '23:00'
+        );
+
+        $openingHours5 = new OpeningHour(
+            ['friday', 'saturday', 'sunday'],
+            '10:00',
+            '15:00'
+        );
+
+        $place = $place->withOpeningHours(
+            [
+                $openingHours1,
+                $openingHours2,
+                $openingHours3,
+                $openingHours4,
+                $openingHours5,
+            ]
+        );
+
+        $this->assertEquals(
+            'Elke dag open' . PHP_EOL,
             $this->formatter->format($place)
         );
     }


### PR DESCRIPTION
### Changed

1.`xs`, `sm` & `md`
- Use `Open every day` if an `Offer` has no closing days.
- Use `Elke ... open` if an `Offer` has only 1 opening day.
- Use abbreviated weekscheme if an Offer has consecutive days it is open (eg. `mo - fr & su`)

2.`lg`
- Use weekday in full in both `HTML-` & `PlainTextFormatter`

---

Ticket: https://jira.uitdatabank.be/browse/III-5087
