### PR TITLE
III-5110 show year consistently

### DIFF
--- a/src/Single/ExtraSmallSingleHTMLFormatter.php
+++ b/src/Single/ExtraSmallSingleHTMLFormatter.php
@@ -65,37 +65,26 @@ final class ExtraSmallSingleHTMLFormatter implements SingleFormatterInterface
 
     private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
     {
-        $dateFromDay = $this->formatter->formatAsDayNumber($dateFrom);
-        $dateFromMonth = $this->formatter->formatAsAbbreviatedMonthName($dateFrom);
-
-        $dateEndDay = $this->formatter->formatAsDayNumber($dateEnd);
-        $dateEndMonth = $this->formatter->formatAsAbbreviatedMonthName($dateEnd);
-
         $output = '<span class="cf-from cf-meta">' . ucfirst($this->translator->translate('from')) . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-date">' . $dateFromDay . '</span>';
-        $output .= ' ';
-        $output .= '<span class="cf-month">' . $dateFromMonth . '</span>';
-        if (!DateComparison::isCurrentYear($dateFrom)) {
-            $output .= ' ';
-            $output .= '<span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';
-        }
+        $output .= $this->getDatePart($dateFrom);
         $output .= ' ';
         $output .= '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>';
         $output .= ' ';
-        $output .= '<span class="cf-date">' . $dateEndDay . '</span>';
-        $output .= ' ';
-        $output .= '<span class="cf-month">' . $dateEndMonth . '</span>';
-        if (!DateComparison::isCurrentYear($dateEnd)) {
-            $output .= ' ';
-            $output .= '<span class="cf-year">' . $this->formatter->formatAsYear($dateEnd) . '</span>';
-        }
+        $output .= $this->getDatePart($dateEnd);
 
         return $output;
     }
 
     private function getDatePart(DateTimeInterface $date): string
     {
-        return ' ';
+        $output = '<span class="cf-date">' . $this->formatter->formatAsDayNumber($date) . '</span>';
+        $output .= ' ';
+        $output .= '<span class="cf-month">' . $this->formatter->formatAsAbbreviatedMonthName($date) . '</span>';
+        if (!DateComparison::isCurrentYear($date)) {
+            $output .= ' ';
+            $output .= '<span class="cf-year">' . $this->formatter->formatAsYear($date) . '</span>';
+        }
+        return $output;
     }
 }

--- a/src/Single/ExtraSmallSingleHTMLFormatter.php
+++ b/src/Single/ExtraSmallSingleHTMLFormatter.php
@@ -52,9 +52,15 @@ final class ExtraSmallSingleHTMLFormatter implements SingleFormatterInterface
         $dateFromDay = $this->formatter->formatAsDayNumber($dateFrom);
         $dateFromMonth = $this->formatter->formatAsAbbreviatedMonthName($dateFrom);
 
-        return '<span class="cf-date">' . ucfirst($dateFromDay) . '</span>'
+        $output = '<span class="cf-date">' . ucfirst($dateFromDay) . '</span>'
             . ' '
             . '<span class="cf-month">' . $dateFromMonth . '</span>';
+
+        if (!DateComparison::isCurrentYear($dateFrom)) {
+            $output .= ' <span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';
+        }
+
+        return $output;
     }
 
     private function formatMoreDays(DateTimeInterface $dateFrom, DateTimeInterface $dateEnd): string
@@ -70,13 +76,26 @@ final class ExtraSmallSingleHTMLFormatter implements SingleFormatterInterface
         $output .= '<span class="cf-date">' . $dateFromDay . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-month">' . $dateFromMonth . '</span>';
+        if (!DateComparison::isCurrentYear($dateFrom)) {
+            $output .= ' ';
+            $output .= '<span class="cf-year">' . $this->formatter->formatAsYear($dateFrom) . '</span>';
+        }
         $output .= ' ';
         $output .= '<span class="cf-to cf-meta">' . $this->translator->translate('till') . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-date">' . $dateEndDay . '</span>';
         $output .= ' ';
         $output .= '<span class="cf-month">' . $dateEndMonth . '</span>';
+        if (!DateComparison::isCurrentYear($dateEnd)) {
+            $output .= ' ';
+            $output .= '<span class="cf-year">' . $this->formatter->formatAsYear($dateEnd) . '</span>';
+        }
 
         return $output;
+    }
+
+    private function getDatePart(DateTimeInterface $date): string
+    {
+        return ' ';
     }
 }

--- a/src/Single/ExtraSmallSinglePlainTextFormatter.php
+++ b/src/Single/ExtraSmallSinglePlainTextFormatter.php
@@ -48,22 +48,35 @@ final class ExtraSmallSinglePlainTextFormatter implements SingleFormatterInterfa
 
     private function formatSameDay(DateTimeInterface $date): string
     {
-        $dayNumber = $this->formatter->formatAsDayNumber($date);
-        $monthName = $this->formatter->formatAsAbbreviatedMonthName($date);
-        return PlainTextSummaryBuilder::singleLine($dayNumber, $monthName);
+        $dateParts = [];
+        $dateParts[] = $this->formatter->formatAsDayNumber($date);
+        $dateParts[] = $this->formatter->formatAsAbbreviatedMonthName($date);
+        if (!DateComparison::isCurrentYear($date)) {
+            $dateParts[] = $this->formatter->formatAsYear($date);
+        }
+
+        return PlainTextSummaryBuilder::singleLine(...$dateParts);
     }
 
     private function formatMoreDays(DateTimeInterface $startDate, DateTimeInterface $endDate): string
     {
-        $startDayNumber = $this->formatter->formatAsDayNumber($startDate);
-        $startMonthName = $this->formatter->formatAsAbbreviatedMonthName($startDate);
+        $startDay = [];
+        $startDay[] = $this->formatter->formatAsDayNumber($startDate);
+        $startDay[] = $this->formatter->formatAsAbbreviatedMonthName($startDate);
+        if (!DateComparison::isCurrentYear($startDate)) {
+            $startDay[] =$this->formatter->formatAsYear($startDate);
+        }
 
-        $endDayNumber = $this->formatter->formatAsDayNumber($endDate);
-        $endMonthName = $this->formatter->formatAsAbbreviatedMonthName($endDate);
+        $endDay = [];
+        $endDay[] = $this->formatter->formatAsDayNumber($endDate);
+        $endDay[] = $this->formatter->formatAsAbbreviatedMonthName($endDate);
+        if (!DateComparison::isCurrentYear($endDate)) {
+            $endDay[] =$this->formatter->formatAsYear($endDate);
+        }
 
         return PlainTextSummaryBuilder::start($this->translator)
-            ->from($startDayNumber, $startMonthName)
-            ->till($endDayNumber, $endMonthName)
+            ->from(...$startDay)
+            ->till(...$endDay)
             ->toString();
     }
 }

--- a/src/Single/ExtraSmallSinglePlainTextFormatter.php
+++ b/src/Single/ExtraSmallSinglePlainTextFormatter.php
@@ -64,14 +64,14 @@ final class ExtraSmallSinglePlainTextFormatter implements SingleFormatterInterfa
         $startDay[] = $this->formatter->formatAsDayNumber($startDate);
         $startDay[] = $this->formatter->formatAsAbbreviatedMonthName($startDate);
         if (!DateComparison::isCurrentYear($startDate)) {
-            $startDay[] =$this->formatter->formatAsYear($startDate);
+            $startDay[] = $this->formatter->formatAsYear($startDate);
         }
 
         $endDay = [];
         $endDay[] = $this->formatter->formatAsDayNumber($endDate);
         $endDay[] = $this->formatter->formatAsAbbreviatedMonthName($endDate);
         if (!DateComparison::isCurrentYear($endDate)) {
-            $endDay[] =$this->formatter->formatAsYear($endDate);
+            $endDay[] = $this->formatter->formatAsYear($endDate);
         }
 
         return PlainTextSummaryBuilder::start($this->translator)

--- a/tests/CalendarPlainTextFormatterTest.php
+++ b/tests/CalendarPlainTextFormatterTest.php
@@ -35,7 +35,7 @@ final class CalendarPlainTextFormatterTest extends TestCase
             CalendarType::single()
         );
 
-        $this->assertSame('25 jan', $this->formatter->format($offer, 'xs'));
+        $this->assertSame('25 jan 2018', $this->formatter->format($offer, 'xs'));
     }
 
     public function testGeneralFormatMethodAndCatchException(): void

--- a/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
+++ b/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -22,6 +23,7 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallSingleHTMLFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 9));
     }
 
     public function testFormatHTMLSingleDateXsOneDay(): void
@@ -57,6 +59,87 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
             '<span class="cf-month">jan</span> ' .
             '<span class="cf-year">2018</span> ' .
             '<span class="cf-status">(geannuleerd)</span>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHtmlSingleDateCurrentYEar(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 1, 8)->setTime(1, 0),
+            CarbonImmutable::create(2021, 1, 8)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            '<span class="cf-date">8</span> <span class="cf-month">jan</span>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHtmlSingleDateXsMoreDaysCurrentYear(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 1, 23)->setTime(1, 0),
+            CarbonImmutable::create(2021, 1, 28)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> ' .
+            '<span class="cf-date">23</span> ' .
+            '<span class="cf-month">jan</span> ' .
+            '<span class="cf-to cf-meta">tot</span> ' .
+            '<span class="cf-date">28</span> ' .
+            '<span class="cf-month">jan</span>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHtmlSingleDateXsMoreDaysStartCurrentYear(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 12, 23)->setTime(1, 0),
+            CarbonImmutable::create(2022, 1, 28)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> ' .
+            '<span class="cf-date">23</span> ' .
+            '<span class="cf-month">dec</span> ' .
+            '<span class="cf-to cf-meta">tot</span> ' .
+            '<span class="cf-date">28</span> ' .
+            '<span class="cf-month">jan</span> ' .
+            '<span class="cf-year">2022</span>',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatHtmlSingleDateXsMoreDaysEndCurrentYear(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2020, 12, 23)->setTime(1, 0),
+            CarbonImmutable::create(2021, 1, 28)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> ' .
+            '<span class="cf-date">23</span> ' .
+            '<span class="cf-month">dec</span> ' .
+            '<span class="cf-year">2020</span> ' .
+            '<span class="cf-to cf-meta">tot</span> ' .
+            '<span class="cf-date">28</span> ' .
+            '<span class="cf-month">jan</span>',
             $this->formatter->format($event)
         );
     }

--- a/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
+++ b/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
@@ -35,7 +35,9 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-date">25</span> <span class="cf-month">jan</span>',
+            '<span class="cf-date">25</span> ' .
+            '<span class="cf-month">jan</span> ' .
+            '<span class="cf-year">2018</span>',
             $this->formatter->format($event)
         );
     }
@@ -51,7 +53,10 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-date">25</span> <span class="cf-month">jan</span> <span class="cf-status">(geannuleerd)</span>',
+            '<span class="cf-date">25</span> ' .
+            '<span class="cf-month">jan</span> ' .
+            '<span class="cf-year">2018</span> ' .
+            '<span class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($event)
         );
     }
@@ -67,7 +72,10 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-date">25</span> <span class="cf-month">jan</span> <span title="Covid-19" class="cf-status">(geannuleerd)</span>',
+            '<span class="cf-date">25</span> ' .
+            '<span class="cf-month">jan</span> ' .
+            '<span class="cf-year">2018</span> ' .
+            '<span title="Covid-19" class="cf-status">(geannuleerd)</span>',
             $this->formatter->format($event)
         );
     }
@@ -83,7 +91,7 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '<span class="cf-date">8</span> <span class="cf-month">jan</span>',
+            '<span class="cf-date">8</span> <span class="cf-month">jan</span> <span class="cf-year">2018</span>',
             $this->formatter->format($event)
         );
     }
@@ -104,11 +112,15 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-month">jan</span>';
         $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-year">2018</span>';
+        $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">27</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-month">jan</span>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-year">2018</span>';
 
         $this->assertEquals(
             $expectedOutput,
@@ -132,11 +144,15 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-month">jan</span>';
         $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-year">2018</span>';
+        $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">27</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-month">jan</span>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-year">2018</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-status">(geannuleerd)</span>';
 
@@ -162,11 +178,15 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-month">jan</span>';
         $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-year">2018</span>';
+        $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-to cf-meta">tot</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-date">8</span>';
         $expectedOutput .= ' ';
         $expectedOutput .= '<span class="cf-month">jan</span>';
+        $expectedOutput .= ' ';
+        $expectedOutput .= '<span class="cf-year">2018</span>';
 
         $this->assertEquals(
             $expectedOutput,

--- a/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
@@ -35,7 +35,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '25 jan',
+            '25 jan 2018',
             $this->formatter->format($event)
         );
     }
@@ -51,7 +51,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '8 jan',
+            '8 jan 2018',
             $this->formatter->format($event)
         );
     }
@@ -67,7 +67,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 jan tot 28 jan',
+            'Van 25 jan 2018 tot 28 jan 2018',
             $this->formatter->format($event)
         );
     }
@@ -83,7 +83,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 6 jan tot 8 jan',
+            'Van 6 jan 2018 tot 8 jan 2018',
             $this->formatter->format($event)
         );
     }
@@ -99,7 +99,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '25 jan (geannuleerd)',
+            '25 jan 2018 (geannuleerd)',
             $this->formatter->format($event)
         );
     }
@@ -115,7 +115,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            '25 jan (uitgesteld)',
+            '25 jan 2018 (uitgesteld)',
             $this->formatter->format($event)
         );
     }
@@ -131,7 +131,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 jan tot 28 jan (geannuleerd)',
+            'Van 25 jan 2018 tot 28 jan 2018 (geannuleerd)',
             $this->formatter->format($event)
         );
     }
@@ -147,7 +147,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 jan tot 28 jan (geannuleerd)',
+            'Van 25 jan 2018 tot 28 jan 2018 (geannuleerd)',
             $this->formatter->format($event)
         );
     }
@@ -163,7 +163,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 jan tot 28 jan (Volzet of uitverkocht)',
+            'Van 25 jan 2018 tot 28 jan 2018 (Volzet of uitverkocht)',
             $this->formatter->format($event)
         );
     }
@@ -179,7 +179,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Van 25 jan tot 28 jan (uitgesteld)',
+            'Van 25 jan 2018 tot 28 jan 2018 (uitgesteld)',
             $this->formatter->format($event)
         );
     }

--- a/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Single;
 
+use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -22,6 +23,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallSinglePlainTextFormatter(new Translator('nl_NL'));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 9));
     }
 
     public function testFormatPlainTextSingleDateXsOneDay(): void
@@ -52,6 +54,70 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
 
         $this->assertEquals(
             '8 jan 2018',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateCurrentYEar(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 1, 8)->setTime(1, 0),
+            CarbonImmutable::create(2021, 1, 8)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            '8 jan',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsMoreDaysCurrentYear(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 1, 23)->setTime(1, 0),
+            CarbonImmutable::create(2021, 1, 28)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            'Van 23 jan tot 28 jan',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsMoreDaysStartCurrentYear(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2021, 12, 23)->setTime(1, 0),
+            CarbonImmutable::create(2022, 1, 28)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            'Van 23 dec tot 28 jan 2022',
+            $this->formatter->format($event)
+        );
+    }
+
+    public function testFormatPlainTextSingleDateXsMoreDaysEndCurrentYear(): void
+    {
+        $event = new Offer(
+            OfferType::event(),
+            new Status('Available', []),
+            new BookingAvailability('Available'),
+            CarbonImmutable::create(2020, 12, 23)->setTime(1, 0),
+            CarbonImmutable::create(2021, 1, 28)->setTime(21, 30)
+        );
+
+        $this->assertEquals(
+            'Van 23 dec 2020 tot 28 jan',
             $this->formatter->format($event)
         );
     }


### PR DESCRIPTION
### Changed

- Show year if the date is not the current year in `xs` to be consistent among different calendar types.

---

Ticket: https://jira.uitdatabank.be/browse/III-5110
