### PR TITLE
Settestnow abstraction

### DIFF
--- a/src/CalendarSummaryTester.php
+++ b/src/CalendarSummaryTester.php
@@ -8,7 +8,7 @@ use Carbon\CarbonImmutable;
 
 final class CalendarSummaryTester
 {
-    public static function setTestNow($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null)
+    public static function setTestNow(int $year = 0, int $month = 1, int $day = 1, int $hour = 0, int $minute = 0, int $second = 0, $tz = null)
     {
         CarbonImmutable::setTestNow(CarbonImmutable::create($year, $month, $day, $hour, $minute, $second, $tz));
     }

--- a/src/CalendarSummaryTester.php
+++ b/src/CalendarSummaryTester.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\CalendarSummaryV3;
+
+use Carbon\CarbonImmutable;
+
+final class CalendarSummaryTester
+{
+    public static function setTestNow($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null)
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::create($year, $month, $day, $hour, $minute, $second, $tz));
+    }
+}

--- a/tests/DateComparisonTest.php
+++ b/tests/DateComparisonTest.php
@@ -11,7 +11,7 @@ final class DateComparisonTest extends TestCase
 {
     protected function setUp(): void
     {
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 4));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 4));
     }
 
     public function testAreTwoDatesOnTheSameDay(): void

--- a/tests/DateComparisonTest.php
+++ b/tests/DateComparisonTest.php
@@ -11,7 +11,7 @@ final class DateComparisonTest extends TestCase
 {
     protected function setUp(): void
     {
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 4));
+        CalendarSummaryTester::setTestNow(2021, 5, 4);
     }
 
     public function testAreTwoDatesOnTheSameDay(): void

--- a/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultipleHTMLFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class ExtraSmallMultipleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallMultipleHTMLFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -25,7 +25,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallMultiplePlainTextFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/ExtraSmallMultiplePlainTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class ExtraSmallMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallMultiplePlainTextFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallMultipleHTMLFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatMultipleOnSamedayToday(): void

--- a/tests/Multiple/SmallMultipleHTMLFormatterTest.php
+++ b/tests/Multiple/SmallMultipleHTMLFormatterTest.php
@@ -25,7 +25,7 @@ final class SmallMultipleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallMultipleHTMLFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatMultipleOnSamedayToday(): void

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Multiple;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallMultiplePlainTextFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
+++ b/tests/Multiple/SmallMultiplePlainTextFormatterTest.php
@@ -25,7 +25,7 @@ final class SmallMultiplePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallMultiplePlainTextFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatMultipleWithoutLeadingZeroes(): void

--- a/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallPeriodicHTMLFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatAPeriodStartsCurrentYear(): void

--- a/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicHTMLFormatterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
-use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
@@ -25,7 +24,7 @@ final class ExtraSmallPeriodicHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallPeriodicHTMLFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatAPeriodStartsCurrentYear(): void

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
-use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
@@ -25,7 +24,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/ExtraSmallPeriodicPlainTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class ExtraSmallPeriodicPlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
-use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
@@ -25,7 +24,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallPeriodicHTMLFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicHTMLFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class SmallPeriodicHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallPeriodicHTMLFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatAPeriodWithoutLeadingZeroes(): void

--- a/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
@@ -24,7 +25,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatAPeriodStartsCurrentYear(): void

--- a/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
+++ b/tests/Periodic/SmallPeriodicPlainTextFormatterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\CalendarSummaryV3\Periodic;
 
-use Carbon\CarbonImmutable;
 use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
@@ -25,7 +24,7 @@ final class SmallPeriodicPlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallPeriodicPlainTextFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatAPeriodStartsCurrentYear(): void

--- a/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
+++ b/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Single;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -23,7 +24,7 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallSingleHTMLFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 9));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 9));
     }
 
     public function testFormatHTMLSingleDateXsOneDay(): void

--- a/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
+++ b/tests/Single/ExtraSmallSingleHTMLFormatterTest.php
@@ -24,7 +24,7 @@ final class ExtraSmallSingleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallSingleHTMLFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 9));
+        CalendarSummaryTester::setTestNow(2021, 5, 9);
     }
 
     public function testFormatHTMLSingleDateXsOneDay(): void

--- a/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Single;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -23,7 +24,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallSinglePlainTextFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 9));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 9));
     }
 
     public function testFormatPlainTextSingleDateXsOneDay(): void

--- a/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/ExtraSmallSinglePlainTextFormatterTest.php
@@ -24,7 +24,7 @@ final class ExtraSmallSinglePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new ExtraSmallSinglePlainTextFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 9));
+        CalendarSummaryTester::setTestNow(2021, 5, 9);
     }
 
     public function testFormatPlainTextSingleDateXsOneDay(): void

--- a/tests/Single/SmallSingleHTMLFormatterTest.php
+++ b/tests/Single/SmallSingleHTMLFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Single;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -23,7 +24,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallSingleHTMLFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatHTMLSingleDateXsOneDay(): void

--- a/tests/Single/SmallSingleHTMLFormatterTest.php
+++ b/tests/Single/SmallSingleHTMLFormatterTest.php
@@ -24,7 +24,7 @@ final class SmallSingleHTMLFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallSingleHTMLFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatHTMLSingleDateXsOneDay(): void

--- a/tests/Single/SmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/SmallSinglePlainTextFormatterTest.php
@@ -24,7 +24,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallSinglePlainTextFormatter(new Translator('nl_NL'));
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(2021, 5, 3);
     }
 
     public function testFormatPlainTextSingleDateSmOneDay(): void
@@ -45,7 +45,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
 
     public function testSameWeekInThePast(): void
     {
-        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 5));
+        CalendarSummaryTester::setTestNow(2021, 5, 5);
 
         $event = new Offer(
             OfferType::event(),

--- a/tests/Single/SmallSinglePlainTextFormatterTest.php
+++ b/tests/Single/SmallSinglePlainTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\CalendarSummaryV3\Single;
 
 use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\CalendarSummaryV3\Offer\OfferType;
@@ -23,7 +24,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
     protected function setUp(): void
     {
         $this->formatter = new SmallSinglePlainTextFormatter(new Translator('nl_NL'));
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 3));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 3));
     }
 
     public function testFormatPlainTextSingleDateSmOneDay(): void
@@ -44,7 +45,7 @@ final class SmallSinglePlainTextFormatterTest extends TestCase
 
     public function testSameWeekInThePast(): void
     {
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2021, 5, 5));
+        CalendarSummaryTester::setTestNow(CarbonImmutable::create(2021, 5, 5));
 
         $event = new Offer(
             OfferType::event(),


### PR DESCRIPTION
### Changed

- Implemented an abstration for `setTestNow()` so we don't introduce bugs by mixing up `Carbon::setTestNow()` & `CarbonImmutable::setTestNow()`

---

Ticket: https://jira.uitdatabank.be/browse/...
