### PR TITLE
Remove newlines between opening hours of a same day

### DIFF
--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -42,6 +42,11 @@ final class PlainTextSummaryBuilder
         return new self($translator);
     }
 
+    public function hasHours()
+    {
+        return count($this->workingLine) > 1;
+    }
+
     public function openAt(string ...$text): self
     {
         return $this->appendTranslation('open_at')->appendMultiple($text, ' & ');
@@ -75,7 +80,7 @@ final class PlainTextSummaryBuilder
     public function fromHour(string ...$text): self
     {
         $self = $this;
-        if ($this->lines) {
+        if ($this->hasHours()) {
             $self = $self->and();
         }
 

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -44,7 +44,7 @@ final class PlainTextSummaryBuilder
 
     public function hasHours()
     {
-        return count($this->workingLine) > 1;
+        return in_array($this->translator->translate('from'), $this->workingLine);
     }
 
     public function openAt(string ...$text): self
@@ -80,7 +80,8 @@ final class PlainTextSummaryBuilder
     public function fromHour(string ...$text): self
     {
         $self = $this;
-        if ($this->hasHours()) {
+        $isLastWordAnd = $this->workingLine[count($this->workingLine) - 1] === $this->translator->translate('and');
+        if (!$isLastWordAnd && $this->hasHours()) {
             $self = $self->and();
         }
 

--- a/src/PlainTextSummaryBuilder.php
+++ b/src/PlainTextSummaryBuilder.php
@@ -42,9 +42,9 @@ final class PlainTextSummaryBuilder
         return new self($translator);
     }
 
-    public function hasHours()
+    public function hasHours(): bool
     {
-        return in_array($this->translator->translate('from'), $this->workingLine);
+        return in_array($this->translator->translate('from'), $this->workingLine, true);
     }
 
     public function openAt(string ...$text): self

--- a/tests/Permanent/LargePermanentPlainTextFormatterTest.php
+++ b/tests/Permanent/LargePermanentPlainTextFormatterTest.php
@@ -70,8 +70,7 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Maandag van 9:00 tot 13:00' . PHP_EOL
-            . 'en van 14:00 tot 20:00' . PHP_EOL
+            'Maandag van 9:00 tot 13:00 en van 14:00 tot 20:00' . PHP_EOL
             . 'Dinsdag van 9:00 tot 13:00' . PHP_EOL
             . 'Woensdag van 9:00 tot 13:00' . PHP_EOL
             . 'Donderdag gesloten' . PHP_EOL
@@ -167,12 +166,12 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Maandag van 9:00 tot 13:00' . PHP_EOL . 'en van 17:00 tot 20:00' . PHP_EOL
-            . 'Dinsdag van 9:00 tot 13:00' . PHP_EOL . 'en van 17:00 tot 20:00' . PHP_EOL
-            . 'Woensdag van 9:00 tot 13:00' . PHP_EOL . 'en van 17:00 tot 20:00' . PHP_EOL
+            'Maandag van 9:00 tot 13:00 en van 17:00 tot 20:00' . PHP_EOL
+            . 'Dinsdag van 9:00 tot 13:00 en van 17:00 tot 20:00' . PHP_EOL
+            . 'Woensdag van 9:00 tot 13:00 en van 17:00 tot 20:00' . PHP_EOL
             . 'Donderdag gesloten' . PHP_EOL
-            . 'Vrijdag van 10:00 tot 15:00' . PHP_EOL . 'en van 18:00 tot 21:00' . PHP_EOL
-            . 'Zaterdag van 10:00 tot 15:00' . PHP_EOL . 'en van 18:00 tot 21:00' . PHP_EOL
+            . 'Vrijdag van 10:00 tot 15:00 en van 18:00 tot 21:00' . PHP_EOL
+            . 'Zaterdag van 10:00 tot 15:00 en van 18:00 tot 21:00' . PHP_EOL
             . 'Zondag gesloten' . PHP_EOL,
             $this->formatter->format($place)
         );
@@ -229,9 +228,8 @@ final class LargePermanentPlainTextFormatterTest extends TestCase
         );
 
         $this->assertEquals(
-            'Maandag van 9:30 tot 13:45' . PHP_EOL . 'en van 17:00 tot 20:00' . PHP_EOL
-            . 'Dinsdag van 9:30 tot 13:45' . PHP_EOL . 'en van 18:00 tot 20:00' . PHP_EOL
-            . 'en van 21:00 tot 23:00' . PHP_EOL
+            'Maandag van 9:30 tot 13:45 en van 17:00 tot 20:00' . PHP_EOL
+            . 'Dinsdag van 9:30 tot 13:45 en van 18:00 tot 20:00 en van 21:00 tot 23:00' . PHP_EOL
             . 'Woensdag gesloten' . PHP_EOL
             . 'Donderdag gesloten' . PHP_EOL
             . 'Vrijdag van 10:00 tot 15:00' . PHP_EOL


### PR DESCRIPTION
### Fixed
- Remove text newlines between opening hours of a same day

### Version to be released if approved
- 4.0.8

---

Ticket: https://jira.publiq.be/browse/III-6186
